### PR TITLE
perf: rewrite the SIMD NPV kernels and make irr() honor its guess

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,15 @@ harness = false
 [[bench]]
 name = "comparison"
 harness = false
+
+[[bench]]
+name = "prefix_irr"
+harness = false
+
+[[bench]]
+name = "npv_kernel"
+harness = false
+
+[[bench]]
+name = "grid_fallback"
+harness = false

--- a/benches/grid_fallback.rs
+++ b/benches/grid_fallback.rs
@@ -1,0 +1,41 @@
+//! Cost of the last-resort `brentq_grid_search` in `irr`.
+//!
+//! Both inputs are constructed to fall through every earlier stage of the cascade — the
+//! bracket searches find no sign change and Newton does not converge — so the grid search
+//! runs to exhaustion. Both have a real IRR just below -99.9%, outside the `[-0.999, 100]`
+//! bracket, which is precisely the region the current breakpoints cannot reach.
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use pyxirr::irr;
+
+/// n=4, root at -0.99950. The tail term is negligible at rate -0.999 but dominates as the
+/// rate approaches -1, which is what puts the root outside the earlier bracket.
+fn short_cash_flow() -> Vec<f64> {
+    vec![-4002.0, 0.001, -0.001, 1e-6]
+}
+
+/// n=20, root at -0.99955. Same shape, but npv reaches ~1e206 at the -0.99999999999999
+/// endpoint, so brentq's interpolation degenerates and it bisects the whole way down.
+fn long_cash_flow() -> Vec<f64> {
+    let mut values = vec![-4002.0];
+    values.extend(std::iter::repeat(0.0).take(18));
+    values.push(1e-60);
+    values
+}
+
+fn bench_grid_fallback(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Grid fallback");
+
+    for (name, values) in [("short_n4", short_cash_flow()), ("long_n20", long_cash_flow())] {
+        // record what the cascade actually returns under the current breakpoints
+        eprintln!("  irr({name}) = {:?}", irr(&values, None));
+
+        group.bench_with_input(BenchmarkId::new("irr", name), &values, |b, values| {
+            b.iter(|| black_box(irr(black_box(values), None)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_grid_fallback);
+criterion_main!(benches);

--- a/benches/grid_fallback.rs
+++ b/benches/grid_fallback.rs
@@ -17,7 +17,7 @@ fn short_cash_flow() -> Vec<f64> {
 /// endpoint, so brentq's interpolation degenerates and it bisects the whole way down.
 fn long_cash_flow() -> Vec<f64> {
     let mut values = vec![-4002.0];
-    values.extend(std::iter::repeat(0.0).take(18));
+    values.extend(std::iter::repeat_n(0.0, 18));
     values.push(1e-60);
     values
 }

--- a/benches/npv_kernel.rs
+++ b/benches/npv_kernel.rs
@@ -1,7 +1,11 @@
 //! Isolates the SIMD NPV kernels from the root-finding above them: `npv` at a fixed rate,
 //! over lengths that straddle the SIMD threshold and the 8-lane block size.
+//!
+//! Also where the `*_MIN_LEN` thresholds are measured: run this with `ENABLE_NEON=0` (or
+//! `ENABLE_AVX2=0 ENABLE_AVX=0`) to time the auto-vectorized fallback at each length, then
+//! with the kernels on, and take the crossover.
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use pyxirr::npv;
+use pyxirr::{irr, npv};
 
 fn cash_flow(len: usize) -> Vec<f64> {
     (0..len)
@@ -15,11 +19,14 @@ fn cash_flow(len: usize) -> Vec<f64> {
         .collect()
 }
 
+/// Lengths straddling every threshold that matters: the SIMD cutoffs (`SIMD256_MIN_LEN`,
+/// `NEON_MIN_LEN`), the 8-lane block size, and the remainders past a whole block.
+const LENGTHS: [usize; 16] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 16, 64, 100, 256, 1024];
+
 fn bench_npv_by_size(c: &mut Criterion) {
     let mut group = c.benchmark_group("NPV kernel");
 
-    // 9 is the first length that takes the SIMD path; 11 and 100 leave a remainder
-    for len in [4usize, 5, 6, 7, 8, 9, 11, 12, 16, 64, 100, 256, 1024] {
+    for len in LENGTHS {
         let values = cash_flow(len);
         group.bench_with_input(BenchmarkId::new("npv", len), &values, |b, values| {
             b.iter(|| black_box(npv(black_box(0.07), black_box(values), Some(true))))
@@ -29,5 +36,20 @@ fn bench_npv_by_size(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_npv_by_size);
+/// `irr` drives the NPV+derivative kernel through Newton, which the `npv`-only group above
+/// never touches. Lengths below 4 take the analytical fast paths, so they start at 4.
+fn bench_irr_by_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("IRR kernel");
+
+    for len in LENGTHS.into_iter().filter(|&len| len >= 4) {
+        let values = cash_flow(len);
+        group.bench_with_input(BenchmarkId::new("irr", len), &values, |b, values| {
+            b.iter(|| black_box(irr(black_box(values), None)))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_npv_by_size, bench_irr_by_size);
 criterion_main!(benches);

--- a/benches/npv_kernel.rs
+++ b/benches/npv_kernel.rs
@@ -1,0 +1,33 @@
+//! Isolates the SIMD NPV kernels from the root-finding above them: `npv` at a fixed rate,
+//! over lengths that straddle the SIMD threshold and the 8-lane block size.
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use pyxirr::npv;
+
+fn cash_flow(len: usize) -> Vec<f64> {
+    (0..len)
+        .map(|i| {
+            if i == 0 {
+                -1.0e6
+            } else {
+                12_500.0 + (i % 11) as f64 * 37.5
+            }
+        })
+        .collect()
+}
+
+fn bench_npv_by_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("NPV kernel");
+
+    // 9 is the first length that takes the SIMD path; 11 and 100 leave a remainder
+    for len in [4usize, 5, 6, 7, 8, 9, 11, 12, 16, 64, 100, 256, 1024] {
+        let values = cash_flow(len);
+        group.bench_with_input(BenchmarkId::new("npv", len), &values, |b, values| {
+            b.iter(|| black_box(npv(black_box(0.07), black_box(values), Some(true))))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_npv_by_size);
+criterion_main!(benches);

--- a/benches/prefix_irr.rs
+++ b/benches/prefix_irr.rs
@@ -1,0 +1,59 @@
+//! Mirrors the consumer workload that motivated this work: an IRR series, where
+//! `irr` is called once per prefix of a cash flow. Consecutive prefixes have very
+//! similar rates, so the previous result is a near-perfect guess for the next one.
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use pyxirr::irr;
+
+#[path = "../tests/common/mod.rs"]
+mod common;
+
+/// Every prefix solved from scratch — what the consumer does today.
+fn prefix_irr_cold(amounts: &[f64]) -> f64 {
+    let mut last = f64::NAN;
+    for k in 2..=amounts.len() {
+        if let Ok(rate) = irr(&amounts[..k], None) {
+            last = rate;
+        }
+    }
+    last
+}
+
+/// Every prefix seeded with the previous prefix's rate.
+fn prefix_irr_warm(amounts: &[f64]) -> f64 {
+    let mut guess = None;
+    let mut last = f64::NAN;
+    for k in 2..=amounts.len() {
+        if let Ok(rate) = irr(&amounts[..k], guess) {
+            if rate.is_finite() {
+                guess = Some(rate);
+            }
+            last = rate;
+        }
+    }
+    last
+}
+
+fn bench_prefix_irr(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Prefix IRR Series");
+
+    let files =
+        [("rw_100", "tests/samples/rw-100.csv"), ("orbit_001", "tests/samples/orbit-001.csv")];
+
+    for (name, file) in files.iter() {
+        let payments = common::load_payments_from_csv(file).unwrap();
+        let (_, amounts) = common::split_payments(&payments);
+
+        group.bench_with_input(BenchmarkId::new("cold", name), &amounts, |b, amounts| {
+            b.iter(|| black_box(prefix_irr_cold(black_box(amounts))))
+        });
+
+        group.bench_with_input(BenchmarkId::new("warm", name), &amounts, |b, amounts| {
+            b.iter(|| black_box(prefix_irr_warm(black_box(amounts))))
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_prefix_irr);
+criterion_main!(benches);

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -18,13 +18,3 @@ impl From<i64> for DateLike {
         Date::from_julian_day(UNIX_EPOCH_JULIAN_DAY + (value as i32)).unwrap().into()
     }
 }
-
-pub struct AmountArray(Vec<f64>);
-
-impl std::ops::Deref for AmountArray {
-    type Target = [f64];
-
-    fn deref(&self) -> &[f64] {
-        self.0.as_ref()
-    }
-}

--- a/src/core/optimize.rs
+++ b/src/core/optimize.rs
@@ -71,6 +71,58 @@ where
     f64::NAN
 }
 
+/// Newton-Raphson seeded from a caller-supplied guess, for use *before* a bracket search.
+///
+/// Differs from [`newton_raphson_2`] in the two ways that matter for a warm start:
+///
+/// * the iteration cap is low — a good guess converges in a few steps, and a bad guess
+///   should fall through to the bracket search cheaply rather than burning 20 iterations;
+/// * convergence is judged on the step size relative to the rate, not on `|f(x)|` against
+///   an absolute tolerance. `newton_raphson_2` accepts only when `|npv| < 1e-3`, which is
+///   unreachable in f64 for cash flows in the billions no matter how exact the rate is.
+///
+/// Returns NaN if it does not converge, or if it walks outside `rate > -1`.
+pub fn newton_raphson_warm<Func>(start: f64, fd: &Func, max_iterations: u32) -> f64
+where
+    Func: Fn(f64) -> (f64, f64),
+{
+    const STEP_RTOL: f64 = 1e-12;
+
+    let mut x = start;
+
+    for _ in 0..max_iterations {
+        let (y0, y1) = fd(x);
+
+        if y0 == 0.0 {
+            return x;
+        }
+
+        // A flat or non-finite derivative gives no usable step.
+        if !y1.is_finite() || y1.abs() < f64::MIN_POSITIVE {
+            return f64::NAN;
+        }
+
+        let delta = y0 / y1;
+
+        if !delta.is_finite() {
+            return f64::NAN;
+        }
+
+        x -= delta;
+
+        // npv is undefined at or below -100%; let the bracket search handle it.
+        if x <= -1.0 {
+            return f64::NAN;
+        }
+
+        if delta.abs() <= STEP_RTOL * (1.0 + x.abs()) {
+            return x;
+        }
+    }
+
+    f64::NAN
+}
+
 pub fn newton_raphson_with_default_deriv<Func>(start: f64, f: Func) -> f64
 where
     Func: Fn(f64) -> f64,

--- a/src/core/periodic.rs
+++ b/src/core/periodic.rs
@@ -3,7 +3,10 @@ mod npv;
 
 use super::{
     models::{validate, InvalidPaymentsError},
-    optimize::{brentq, brentq_grid_search, newton_raphson_2, newton_raphson_with_default_deriv},
+    optimize::{
+        brentq, brentq_grid_search, newton_raphson_2, newton_raphson_warm,
+        newton_raphson_with_default_deriv,
+    },
     utils::{self},
 };
 
@@ -463,7 +466,30 @@ pub fn irr(values: &[f64], guess: Option<f64>) -> Result<f64, InvalidPaymentsErr
         return Ok(irr::irr_analytical_3(values));
     }
 
-    let initial_guess = guess.unwrap_or(0.1);
+    // A caller-supplied guess means "the root is near here". The dominant case is an IRR
+    // series, where each period's rate is close to the previous period's, so Newton from
+    // that start converges in a couple of iterations. The bracket search below ignores the
+    // guess entirely and always sweeps [0, 100], so without this the guess only ever took
+    // effect when brentq failed outright.
+    //
+    // Capped low: a guess that turns out to be bad costs a few NPV evaluations before
+    // falling through to the unchanged cascade.
+    // `npv_scale` and `initial_guess` are both O(n), so they stay off the path taken when
+    // the bracket search below succeeds on its own — which is the common case.
+    if let Some(guess) = guess {
+        const WARM_START_ITERATIONS: u32 = 6;
+
+        let rate = newton_raphson_warm(
+            guess,
+            &|r| npv::npv_with_deriv_simd(r, values),
+            WARM_START_ITERATIONS,
+        );
+
+        let tolerance = utils::converged_rate_tolerance(utils::npv_scale(values));
+        if utils::is_a_good_rate_within(rate, tolerance, |r| npv(r, values, Some(true))) {
+            return Ok(rate);
+        }
+    }
 
     // Try Brent with positive brackets
     let rate = brentq(&|r| npv(r, values, Some(true)), 0.0, 100.0, 100);
@@ -471,10 +497,27 @@ pub fn irr(values: &[f64], guess: Option<f64>) -> Result<f64, InvalidPaymentsErr
         return Ok(rate);
     }
 
-    // Fallback to Newton-Raphson
+    // Fallback to Newton-Raphson. The seed is derived from the cash flow rather than a flat
+    // 0.1, which starts on the wrong side of zero for the loss-making prefixes of an IRR
+    // series. `xirr` already seeds this way.
+    let initial_guess = guess.unwrap_or_else(|| {
+        // npv(0) is just the sum of the cash flow, and npv decreases in the rate, so a
+        // negative sum puts the root below zero — where a flat 0.1 seed starts on the wrong
+        // side and Newton has to walk back across it. That is the loss-making prefix of an
+        // IRR series. Seeding from the data only in that case leaves the (much more common)
+        // positive-rate cash flows on their original, well-tuned 0.1 start.
+        if values.iter().sum::<f64>() < 0.0 {
+            utils::initial_guess(values)
+        } else {
+            0.1
+        }
+    });
     let rate = newton_raphson_2(initial_guess, &|r| npv::npv_with_deriv_simd(r, values));
 
-    if utils::is_a_good_rate(rate, |r| npv(r, values, Some(true))) {
+    // Scale-relative: with a flat 1e-3 this rejected perfectly good rates for large cash
+    // flows and fell through to the expensive [-0.999, 100] sweep below.
+    let tolerance = utils::approximate_rate_tolerance(utils::npv_scale(values));
+    if utils::is_a_good_rate_within(rate, tolerance, |r| npv(r, values, Some(true))) {
         return Ok(rate);
     }
 
@@ -485,7 +528,7 @@ pub fn irr(values: &[f64], guess: Option<f64>) -> Result<f64, InvalidPaymentsErr
     }
 
     // Final fallback with minimal iterations (to avoid the catastrophic slowdown)
-    let breakpoints = &[-0.9, -0.5, 0.0, 0.5, 1.0];
+    let breakpoints = &[-0.99999999999999, -0.75, -0.5, -0.25, 0., 0.25, 0.5, 1.0, 1e6];
     let f = |r| npv(r, values, Some(true));
     let rate = brentq_grid_search(&[breakpoints], &f).next();
 

--- a/src/core/periodic/npv.rs
+++ b/src/core/periodic/npv.rs
@@ -322,110 +322,6 @@ impl SimdOps for Avx2Ops {
     }
 }
 
-/// NEON implementation for ARM
-#[cfg(target_arch = "aarch64")]
-struct NeonOps;
-
-#[cfg(target_arch = "aarch64")]
-impl SimdOps for NeonOps {
-    unsafe fn process_npv_chunk(
-        base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-    ) -> (f64, f64) {
-        use std::arch::aarch64::*;
-
-        let vec_base = vdupq_n_f64(base);
-        let vec_power_base = vdupq_n_f64(power);
-
-        // Create multipliers [1, base]
-        let vec_mult = vcombine_f64(vdup_n_f64(1.0), vdup_n_f64(base));
-
-        // Multiply to get powers
-        let vec_power = vmulq_f64(vec_power_base, vec_mult);
-
-        // Load values
-        let vec_values = vld1q_f64(&values[start_idx]);
-
-        // Divide values by powers
-        let vec_result = vdivq_f64(vec_values, vec_power);
-
-        // Sum the results
-        let mut result_array = [0.0; 2];
-        vst1q_f64(result_array.as_mut_ptr(), vec_result);
-        let sum = result_array.iter().sum::<f64>();
-
-        // Return sum and updated power
-        (sum, power * Self::precompute_power_factor(base))
-    }
-
-    unsafe fn process_npv_deriv_chunk(
-        base: f64,
-        inv_base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-        start_index: usize,
-    ) -> (f64, f64, f64) {
-        use std::arch::aarch64::*;
-
-        let vec_base = vdupq_n_f64(base);
-        let vec_power_base = vdupq_n_f64(power);
-        let vec_inv_base = vdupq_n_f64(inv_base);
-        let vec_neg_one = vdupq_n_f64(-1.0);
-
-        // Create multipliers [1, base]
-        let vec_mult = vcombine_f64(vdup_n_f64(1.0), vdup_n_f64(base));
-
-        // Multiply to get powers
-        let vec_power = vmulq_f64(vec_power_base, vec_mult);
-
-        // Load values
-        let vec_values = vld1q_f64(&values[start_idx]);
-
-        // Create index vector for derivative
-        let vec_indices = vcombine_f64(
-            vdup_n_f64((start_index + start_idx) as f64),
-            vdup_n_f64((start_index + start_idx + 1) as f64),
-        );
-
-        // Calculate terms
-        let vec_term = vdivq_f64(vec_values, vec_power);
-
-        // Calculate derivative terms
-        let vec_deriv = vmulq_f64(vec_indices, vec_term);
-        let vec_deriv = vmulq_f64(vec_deriv, vec_inv_base);
-        let vec_deriv = vmulq_f64(vec_deriv, vec_neg_one);
-
-        // Store results
-        let mut term_array = [0.0; 2];
-        let mut deriv_array = [0.0; 2];
-        vst1q_f64(term_array.as_mut_ptr(), vec_term);
-        vst1q_f64(deriv_array.as_mut_ptr(), vec_deriv);
-
-        let sum = term_array.iter().sum::<f64>();
-        let deriv = deriv_array.iter().sum::<f64>();
-
-        (sum, deriv, power * Self::precompute_power_factor(base))
-    }
-
-    fn chunk_size() -> usize {
-        2
-    }
-
-    unsafe fn precompute_power_factor(base: f64) -> f64 {
-        use std::arch::aarch64::*;
-        let vec_base = vdupq_n_f64(base);
-        let vec_base_squared = vmulq_f64(vec_base, vec_base);
-        vgetq_lane_f64(vec_base_squared, 0)
-    }
-
-    fn is_supported() -> bool {
-        true
-    }
-}
-
 /// Auto-vectorized implementation
 struct AutoVecOps;
 
@@ -761,18 +657,228 @@ macro_rules! define_simd256_kernels {
 define_simd256_kernels!(npv_simd_avx2, npv_with_deriv_avx2, "avx2,fma", madd_fma);
 define_simd256_kernels!(npv_simd_avx, npv_with_deriv_avx, "avx", madd_mul_add);
 
+/// Lanes consumed per iteration of the NEON kernels. A NEON vector holds two doubles, so
+/// four of them are unrolled per iteration: that gives the same four independent
+/// accumulator chains as the 256-bit kernels, which is what keeps the loop throughput-bound
+/// rather than stalled on the ~4-cycle FMA latency.
 #[cfg(target_arch = "aarch64")]
+const NEON_BLOCK: usize = 8;
+
+/// Shortest slice worth entering [`npv_simd_neon`] for, rather than the auto-vectorized
+/// fallback. Measured on Apple M2, not assumed — see `benches/npv_kernel.rs`.
+#[cfg(target_arch = "aarch64")]
+const NEON_MIN_LEN: usize = 3;
+
+/// The same threshold for [`npv_with_deriv_neon`], which is higher: that kernel sets up
+/// eight vectors (four discount-factor chains, four index chains) before its first
+/// multiply, and only a whole 8-element block pays that back. Below this, `irr` measured
+/// slower with the kernel than without it. The kernel is handed `&values[1..]`, so a slice
+/// of this length gives it exactly one block.
+#[cfg(target_arch = "aarch64")]
+const NEON_DERIV_MIN_LEN: usize = NEON_BLOCK + 1;
+
+/// NPV over the whole slice in one pass.
+///
+/// Replaces the per-chunk `SimdOps` path, which rebuilt `[1, base]` and `base²` for every
+/// two elements, divided by the discount factor, and round-tripped the pair through the
+/// stack to sum it — two lanes of work per call, with a serial dependency between calls.
+/// Here the powers of `1/base` are carried in registers across four independent chains, the
+/// division becomes a multiply-accumulate, and there is exactly one horizontal reduction at
+/// the end.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
 unsafe fn npv_simd_neon(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
-    npv_simd_generic::<NeonOps>(base, values, start_from_zero)
+    use std::arch::aarch64::*;
+
+    let inv_base = 1.0 / base;
+    let ib2 = inv_base * inv_base;
+    let ib4 = ib2 * ib2;
+    let ib8 = ib4 * ib4;
+
+    // discount factor of the first element: base^0 or base^-1
+    let p0 = if start_from_zero {
+        1.0
+    } else {
+        inv_base
+    };
+
+    // pow_j carries the factors of elements i + 2j and i + 2j + 1
+    let mut pow0 = vcombine_f64(vdup_n_f64(p0), vdup_n_f64(p0 * inv_base));
+    let mut pow1 = vmulq_n_f64(pow0, ib2);
+    let mut pow2 = vmulq_n_f64(pow0, ib4);
+    let mut pow3 = vmulq_n_f64(pow1, ib4);
+    let step = vdupq_n_f64(ib8);
+
+    let mut acc0 = vdupq_n_f64(0.0);
+    let mut acc1 = vdupq_n_f64(0.0);
+    let mut acc2 = vdupq_n_f64(0.0);
+    let mut acc3 = vdupq_n_f64(0.0);
+
+    let ptr = values.as_ptr();
+    let len = values.len();
+    let blocks = len / NEON_BLOCK;
+
+    for k in 0..blocks {
+        let i = k * NEON_BLOCK;
+        acc0 = vfmaq_f64(acc0, vld1q_f64(ptr.add(i)), pow0);
+        acc1 = vfmaq_f64(acc1, vld1q_f64(ptr.add(i + 2)), pow1);
+        acc2 = vfmaq_f64(acc2, vld1q_f64(ptr.add(i + 4)), pow2);
+        acc3 = vfmaq_f64(acc3, vld1q_f64(ptr.add(i + 6)), pow3);
+        pow0 = vmulq_f64(pow0, step);
+        pow1 = vmulq_f64(pow1, step);
+        pow2 = vmulq_f64(pow2, step);
+        pow3 = vmulq_f64(pow3, step);
+    }
+
+    // Up to three whole pairs are left over; each already has its factors in pow_j, so the
+    // remainder costs no extra power arithmetic. `tail_pow` tracks the vector whose lane 0
+    // is the factor of the next unprocessed element.
+    let mut i = blocks * NEON_BLOCK;
+    let mut tail_pow = pow0;
+    if len - i >= 2 {
+        acc0 = vfmaq_f64(acc0, vld1q_f64(ptr.add(i)), pow0);
+        i += 2;
+        tail_pow = pow1;
+    }
+    if len - i >= 2 {
+        acc1 = vfmaq_f64(acc1, vld1q_f64(ptr.add(i)), pow1);
+        i += 2;
+        tail_pow = pow2;
+    }
+    if len - i >= 2 {
+        acc2 = vfmaq_f64(acc2, vld1q_f64(ptr.add(i)), pow2);
+        i += 2;
+        tail_pow = pow3;
+    }
+
+    let acc = vaddq_f64(vaddq_f64(acc0, acc1), vaddq_f64(acc2, acc3));
+    let mut sum = vaddvq_f64(acc);
+
+    // at most one element left
+    if i < len {
+        sum += *ptr.add(i) * vgetq_lane_f64::<0>(tail_pow);
+    }
+
+    sum
 }
 
 fn npv_autovec(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
     unsafe { npv_simd_generic::<AutoVecOps>(base, values, start_from_zero) }
 }
 
+/// NPV and its derivative over the whole slice in one pass.
+///
+/// Same treatment as [`npv_simd_neon`], plus: the index vector is carried and incremented
+/// rather than rebuilt from two `usize -> f64` conversions per chunk, and the `-1/base`
+/// factor common to every derivative term is applied once at the end instead of per element.
 #[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
 unsafe fn npv_with_deriv_neon(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
-    npv_with_deriv_generic::<NeonOps>(rate, values, start_index)
+    use std::arch::aarch64::*;
+
+    let base = 1.0 + rate;
+    let inv_base = 1.0 / base;
+    let ib2 = inv_base * inv_base;
+    let ib4 = ib2 * ib2;
+    let ib8 = ib4 * ib4;
+
+    // Matches `npv_with_deriv_generic`: the discount exponent starts at 1 whatever
+    // `start_index` is — the caller has already handled element 0 — while `start_index`
+    // only feeds the derivative's index weights. The two coincide for the production
+    // call, which passes `&values[1..]` with `start_index == 1`.
+    let p0 = inv_base;
+
+    let mut pow0 = vcombine_f64(vdup_n_f64(p0), vdup_n_f64(p0 * inv_base));
+    let mut pow1 = vmulq_n_f64(pow0, ib2);
+    let mut pow2 = vmulq_n_f64(pow0, ib4);
+    let mut pow3 = vmulq_n_f64(pow1, ib4);
+    let step = vdupq_n_f64(ib8);
+
+    let si = start_index as f64;
+    let mut idx0 = vcombine_f64(vdup_n_f64(si), vdup_n_f64(si + 1.0));
+    let mut idx1 = vaddq_f64(idx0, vdupq_n_f64(2.0));
+    let mut idx2 = vaddq_f64(idx0, vdupq_n_f64(4.0));
+    let mut idx3 = vaddq_f64(idx0, vdupq_n_f64(6.0));
+    let idx_step = vdupq_n_f64(NEON_BLOCK as f64);
+
+    let mut sum0 = vdupq_n_f64(0.0);
+    let mut sum1 = vdupq_n_f64(0.0);
+    let mut sum2 = vdupq_n_f64(0.0);
+    let mut sum3 = vdupq_n_f64(0.0);
+    // accumulate sum(i * v_i / base^i); scaled by -1/base once the loop is done
+    let mut wgt0 = vdupq_n_f64(0.0);
+    let mut wgt1 = vdupq_n_f64(0.0);
+    let mut wgt2 = vdupq_n_f64(0.0);
+    let mut wgt3 = vdupq_n_f64(0.0);
+
+    let ptr = values.as_ptr();
+    let len = values.len();
+    let blocks = len / NEON_BLOCK;
+
+    for k in 0..blocks {
+        let i = k * NEON_BLOCK;
+
+        let term0 = vmulq_f64(vld1q_f64(ptr.add(i)), pow0);
+        let term1 = vmulq_f64(vld1q_f64(ptr.add(i + 2)), pow1);
+        let term2 = vmulq_f64(vld1q_f64(ptr.add(i + 4)), pow2);
+        let term3 = vmulq_f64(vld1q_f64(ptr.add(i + 6)), pow3);
+
+        sum0 = vaddq_f64(sum0, term0);
+        sum1 = vaddq_f64(sum1, term1);
+        sum2 = vaddq_f64(sum2, term2);
+        sum3 = vaddq_f64(sum3, term3);
+
+        wgt0 = vfmaq_f64(wgt0, term0, idx0);
+        wgt1 = vfmaq_f64(wgt1, term1, idx1);
+        wgt2 = vfmaq_f64(wgt2, term2, idx2);
+        wgt3 = vfmaq_f64(wgt3, term3, idx3);
+
+        pow0 = vmulq_f64(pow0, step);
+        pow1 = vmulq_f64(pow1, step);
+        pow2 = vmulq_f64(pow2, step);
+        pow3 = vmulq_f64(pow3, step);
+
+        idx0 = vaddq_f64(idx0, idx_step);
+        idx1 = vaddq_f64(idx1, idx_step);
+        idx2 = vaddq_f64(idx2, idx_step);
+        idx3 = vaddq_f64(idx3, idx_step);
+    }
+
+    let mut i = blocks * NEON_BLOCK;
+    let mut tail_pow = pow0;
+    if len - i >= 2 {
+        let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow0);
+        sum0 = vaddq_f64(sum0, term);
+        wgt0 = vfmaq_f64(wgt0, term, idx0);
+        i += 2;
+        tail_pow = pow1;
+    }
+    if len - i >= 2 {
+        let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow1);
+        sum1 = vaddq_f64(sum1, term);
+        wgt1 = vfmaq_f64(wgt1, term, idx1);
+        i += 2;
+        tail_pow = pow2;
+    }
+    if len - i >= 2 {
+        let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow2);
+        sum2 = vaddq_f64(sum2, term);
+        wgt2 = vfmaq_f64(wgt2, term, idx2);
+        i += 2;
+        tail_pow = pow3;
+    }
+
+    let mut sum = vaddvq_f64(vaddq_f64(vaddq_f64(sum0, sum1), vaddq_f64(sum2, sum3)));
+    let mut weighted = vaddvq_f64(vaddq_f64(vaddq_f64(wgt0, wgt1), vaddq_f64(wgt2, wgt3)));
+
+    // at most one element left
+    if i < len {
+        let term = *ptr.add(i) * vgetq_lane_f64::<0>(tail_pow);
+        sum += term;
+        weighted += (start_index + i) as f64 * term;
+    }
+
+    (sum, -weighted * inv_base)
 }
 
 fn npv_with_deriv_autovec(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
@@ -810,8 +916,9 @@ fn simd_tier() -> SimdTier {
     *TIER
 }
 
-/// NEON enablement, cached once. The original dispatch checked only the `ENABLE_NEON`
-/// env var (never `NeonOps::is_supported()`), so this preserves that exact behavior.
+/// NEON enablement, cached once. There is no CPU probe to pair it with: NEON is mandatory
+/// on aarch64, so the env var is the only thing that can turn these kernels off — which is
+/// what `benches/npv_kernel.rs` uses to time the fallback.
 #[cfg(target_arch = "aarch64")]
 fn neon_enabled() -> bool {
     static ENABLED: std::sync::LazyLock<bool> =
@@ -842,10 +949,7 @@ pub fn npv_simd(rate: f64, values: &[f64], start_from_zero: Option<bool>) -> f64
 
     #[cfg(target_arch = "aarch64")]
     {
-        // NEON still runs the original per-chunk kernel, so it keeps the original
-        // threshold. `SIMD256_MIN_LEN` was measured for the rewritten x86 kernels on
-        // x86 hardware and does not transfer; re-measure on ARM before reusing it.
-        if neon_enabled() && values.len() > 8 {
+        if neon_enabled() && values.len() >= NEON_MIN_LEN {
             return unsafe { npv_simd_neon(base, values, start_from_zero) };
         }
     }
@@ -894,10 +998,7 @@ pub fn npv_with_deriv_simd(rate: f64, values: &[f64]) -> (f64, f64) {
 
     #[cfg(target_arch = "aarch64")]
     {
-        // NEON still runs the original per-chunk kernel, so it keeps the original
-        // threshold. `SIMD256_MIN_LEN` was measured for the rewritten x86 kernels on
-        // x86 hardware and does not transfer; re-measure on ARM before reusing it.
-        if neon_enabled() && values.len() > 8 {
+        if neon_enabled() && values.len() >= NEON_DERIV_MIN_LEN {
             let (simd_sum, simd_deriv) = unsafe { npv_with_deriv_neon(rate, &values[1..], 1) };
             return (sum + simd_sum, deriv + simd_deriv);
         }
@@ -1034,7 +1135,7 @@ mod tests {
             // Test NEON implementation on ARM
             #[cfg(target_arch = "aarch64")]
             {
-                let neon_npv = test_npv_implementation::<NeonOps>(values, rate);
+                let neon_npv = unsafe { npv_simd_neon(1.0 + rate, values, true) };
                 assert!(
                     (neon_npv - ref_npv).abs() < 1e-6,
                     "NEON NPV failed for len {}: got {}, expected {}",
@@ -1043,7 +1144,7 @@ mod tests {
                     ref_npv
                 );
 
-                let (neon_sum, neon_deriv) = test_npv_deriv_implementation::<NeonOps>(values, rate);
+                let (neon_sum, neon_deriv) = unsafe { npv_with_deriv_neon(rate, values, 0) };
                 assert!(
                     (neon_sum - ref_sum).abs() < 1e-6 && (neon_deriv - ref_deriv).abs() < 1e-6,
                     "NEON NPV+deriv failed for len {}",
@@ -1116,7 +1217,7 @@ mod tests {
 
             #[cfg(target_arch = "aarch64")]
             {
-                let neon_npv = unsafe { npv_simd_generic::<NeonOps>(base, values, false) };
+                let neon_npv = unsafe { npv_simd_neon(base, values, false) };
                 assert!(
                     (neon_npv - ref_npv).abs() < 1e-6,
                     "NEON NPV(non-zero start) failed for len {}: got {}, expected {}",
@@ -1182,7 +1283,7 @@ mod tests {
             #[cfg(target_arch = "aarch64")]
             {
                 let (neon_sum, neon_deriv) =
-                    unsafe { npv_with_deriv_generic::<NeonOps>(rate, values, start_index) };
+                    unsafe { npv_with_deriv_neon(rate, values, start_index) };
                 assert!(
                     (neon_sum - ref_sum).abs() < 1e-6 && (neon_deriv - ref_deriv).abs() < 1e-6,
                     "NEON NPV+deriv with start_index failed for len {}",
@@ -1385,6 +1486,99 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    /// The rewritten NEON kernels must agree with the scalar reference at every length:
+    /// below the 8-lane block, exactly on a block boundary, and at each of the seven
+    /// possible remainders — which on NEON split into up to three whole pairs plus a
+    /// single scalar element.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn test_neon_kernels_match_reference() {
+        for &rate in &[0.05, 0.12, -0.35, 0.9, 2.5, 1e-6, -0.999] {
+            let base = 1.0 + rate;
+
+            for len in 0..40usize {
+                // varied signs and magnitudes, deterministic
+                let values: Vec<f64> = (0..len)
+                    .map(|i| {
+                        let x = (i as f64 + 1.0) * 137.0357;
+                        if i % 3 == 0 {
+                            -x * 1000.0
+                        } else {
+                            x
+                        }
+                    })
+                    .collect();
+
+                for &start_from_zero in &[true, false] {
+                    let got = unsafe { npv_simd_neon(base, &values, start_from_zero) };
+                    let want =
+                        unsafe { npv_simd_generic::<AutoVecOps>(base, &values, start_from_zero) };
+                    let tol = 1e-9 * want.abs().max(1.0);
+                    assert!(
+                        (got - want).abs() <= tol,
+                        "npv mismatch: rate {rate}, len {len}, start_from_zero {start_from_zero}: got {got}, want {want}"
+                    );
+                }
+
+                for &start_index in &[0usize, 1, 5] {
+                    let (got_sum, got_deriv) =
+                        unsafe { npv_with_deriv_neon(rate, &values, start_index) };
+                    let (want_sum, want_deriv) =
+                        unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, &values, start_index) };
+
+                    let sum_tol = 1e-9 * want_sum.abs().max(1.0);
+                    let deriv_tol = 1e-9 * want_deriv.abs().max(1.0);
+                    assert!(
+                        (got_sum - want_sum).abs() <= sum_tol,
+                        "deriv-sum mismatch: rate {rate}, len {len}, start_index {start_index}: got {got_sum}, want {want_sum}"
+                    );
+                    assert!(
+                        (got_deriv - want_deriv).abs() <= deriv_tol,
+                        "deriv mismatch: rate {rate}, len {len}, start_index {start_index}: got {got_deriv}, want {want_deriv}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Long series: the reciprocal-power chain accumulates error over the whole slice, so
+    /// check it stays negligible rather than assuming it does.
+    #[cfg(target_arch = "aarch64")]
+    #[test]
+    fn test_neon_kernels_long_series_accuracy() {
+        let values: Vec<f64> = (0..5000)
+            .map(|i| {
+                if i == 0 {
+                    -1.0e8
+                } else {
+                    25_000.0 + (i % 7) as f64 * 13.0
+                }
+            })
+            .collect();
+
+        for &rate in &[0.004, 0.05, 0.35] {
+            let base = 1.0 + rate;
+
+            let got = unsafe { npv_simd_neon(base, &values, true) };
+            let want = get_reference_npv(&values, rate);
+            assert!(
+                (got - want).abs() <= 1e-9 * want.abs().max(1.0),
+                "long npv drift: rate {rate}: got {got}, want {want}"
+            );
+
+            let (got_sum, got_deriv) = unsafe { npv_with_deriv_neon(rate, &values[1..], 1) };
+            let (want_sum, want_deriv) = get_reference_npv_deriv(&values[1..], rate, 1);
+            assert!(
+                (got_sum - want_sum).abs() <= 1e-9 * want_sum.abs().max(1.0),
+                "long deriv-sum drift: rate {rate}: got {got_sum}, want {want_sum}"
+            );
+            assert!(
+                (got_deriv - want_deriv).abs() <= 1e-9 * want_deriv.abs().max(1.0),
+                "long deriv drift: rate {rate}: got {got_deriv}, want {want_deriv}"
+            );
         }
     }
 

--- a/src/core/periodic/npv.rs
+++ b/src/core/periodic/npv.rs
@@ -1,404 +1,28 @@
-/// Trait to abstract SIMD operations for different architectures
-trait SimdOps {
-    /// Process a chunk of data for NPV calculation
-    unsafe fn process_npv_chunk(
-        base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-    ) -> (f64, f64); // returns (sum, new_power)
-
-    /// Process a chunk for NPV with derivative calculation
-    unsafe fn process_npv_deriv_chunk(
-        base: f64,
-        inv_base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-        start_index: usize,
-    ) -> (f64, f64, f64); // returns (sum, deriv, new_power)
-
-    /// Get chunk size for processing
-    fn chunk_size() -> usize;
-
-    /// Get precomputed power for updating between chunks
-    unsafe fn precompute_power_factor(base: f64) -> f64;
-
-    /// Check if this implementation is supported on current CPU
-    fn is_supported() -> bool;
+/// CPU support for the AVX2+FMA tier. Kept as a free function rather than a method on a
+/// per-tier type: dispatch and the kernel tests are the only callers.
+#[cfg(target_arch = "x86_64")]
+fn avx2_supported() -> bool {
+    is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")
 }
 
-/// AVX implementation
+/// CPU support for the plain-AVX tier.
 #[cfg(target_arch = "x86_64")]
-struct AvxOps;
-
-#[cfg(target_arch = "x86_64")]
-impl SimdOps for AvxOps {
-    #[target_feature(enable = "avx")]
-    unsafe fn process_npv_chunk(
-        base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-    ) -> (f64, f64) {
-        use std::arch::x86_64::*;
-
-        // Prefetch next chunk for better memory performance
-        if start_idx + 8 < values.len() {
-            _mm_prefetch::<_MM_HINT_T0>(values.as_ptr().add(start_idx + 8) as *const i8);
-        }
-
-        let vec_base = _mm256_set1_pd(base);
-        let vec_power_base = _mm256_set1_pd(power);
-
-        // Create multipliers [1, base, base^2, base^3] more efficiently
-        let vec_base_squared = _mm256_mul_pd(vec_base, vec_base);
-        let vec_base_cubed = _mm256_mul_pd(vec_base_squared, vec_base);
-        let vec_mult = _mm256_set_pd(
-            _mm256_cvtsd_f64(vec_base_cubed),
-            _mm256_cvtsd_f64(vec_base_squared),
-            base,
-            1.0,
-        );
-
-        // Multiply to get powers
-        let vec_power = _mm256_mul_pd(vec_power_base, vec_mult);
-
-        // Alignment-aware load
-        let vec_values = if (values.as_ptr() as usize + start_idx * 8) % 32 == 0 {
-            _mm256_load_pd(&values[start_idx])
-        } else {
-            _mm256_loadu_pd(&values[start_idx])
-        };
-
-        // Divide values by powers
-        let vec_result = _mm256_div_pd(vec_values, vec_power);
-
-        // // Use horizontal add to sum up the 4 packed doubles:
-        // let hadd = _mm256_hadd_pd(vec_result, vec_result);
-        // let low128 = _mm256_castpd256_pd128(hadd);
-        // let high128 = _mm256_extractf128_pd(hadd, 1);
-        // let sum128 = _mm_add_pd(low128, high128);
-        // let sum = _mm_cvtsd_f64(sum128);
-
-        // Sum the results
-        let mut result_array = [0.0; 4];
-        _mm256_storeu_pd(result_array.as_mut_ptr(), vec_result);
-        let sum = result_array.iter().sum::<f64>();
-
-        // Return sum and updated power
-        (sum, power * Self::precompute_power_factor(base))
-    }
-
-    #[target_feature(enable = "avx")]
-    unsafe fn process_npv_deriv_chunk(
-        base: f64,
-        inv_base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-        start_index: usize,
-    ) -> (f64, f64, f64) {
-        use std::arch::x86_64::*;
-
-        // Prefetch next chunk
-        if start_idx + 8 < values.len() {
-            _mm_prefetch::<_MM_HINT_T0>(values.as_ptr().add(start_idx + 8) as *const i8);
-        }
-
-        let vec_base = _mm256_set1_pd(base);
-        let vec_power_base = _mm256_set1_pd(power);
-        let vec_inv_base = _mm256_set1_pd(inv_base);
-        let vec_neg_one = _mm256_set1_pd(-1.0);
-
-        // More efficient power calculation
-        let vec_base_squared = _mm256_mul_pd(vec_base, vec_base);
-        let vec_base_cubed = _mm256_mul_pd(vec_base_squared, vec_base);
-        let vec_mult = _mm256_set_pd(
-            _mm256_cvtsd_f64(vec_base_cubed),
-            _mm256_cvtsd_f64(vec_base_squared),
-            base,
-            1.0,
-        );
-
-        // Multiply to get powers
-        let vec_power = _mm256_mul_pd(vec_power_base, vec_mult);
-
-        // Alignment-aware load
-        let vec_values = if (values.as_ptr() as usize + start_idx * 8) % 32 == 0 {
-            _mm256_load_pd(&values[start_idx])
-        } else {
-            _mm256_loadu_pd(&values[start_idx])
-        };
-
-        // More efficient index vector creation
-        let offset = start_index + start_idx;
-        let vec_indices = _mm256_set_pd(
-            (offset + 3) as f64,
-            (offset + 2) as f64,
-            (offset + 1) as f64,
-            offset as f64,
-        );
-
-        // Calculate terms
-        let vec_term = _mm256_div_pd(vec_values, vec_power);
-
-        // Combined calculation for derivative terms
-        let vec_deriv = _mm256_mul_pd(
-            _mm256_mul_pd(_mm256_mul_pd(vec_indices, vec_term), vec_inv_base),
-            vec_neg_one,
-        );
-
-        // Store results
-        let mut term_array = [0.0; 4];
-        let mut deriv_array = [0.0; 4];
-        _mm256_storeu_pd(term_array.as_mut_ptr(), vec_term);
-        _mm256_storeu_pd(deriv_array.as_mut_ptr(), vec_deriv);
-
-        let sum = term_array.iter().sum::<f64>();
-        let deriv = deriv_array.iter().sum::<f64>();
-
-        (sum, deriv, power * Self::precompute_power_factor(base))
-    }
-
-    fn chunk_size() -> usize {
-        4
-    }
-
-    #[target_feature(enable = "avx")]
-    unsafe fn precompute_power_factor(base: f64) -> f64 {
-        use std::arch::x86_64::*;
-        let vec_base = _mm256_set1_pd(base);
-        let vec_base_squared = _mm256_mul_pd(vec_base, vec_base);
-        let vec_base4 = _mm256_mul_pd(vec_base_squared, vec_base_squared);
-        _mm256_cvtsd_f64(vec_base4)
-    }
-
-    fn is_supported() -> bool {
-        is_x86_feature_detected!("avx")
-    }
+fn avx_supported() -> bool {
+    is_x86_feature_detected!("avx")
 }
 
-/// AVX2+FMA implementation
-#[cfg(target_arch = "x86_64")]
-struct Avx2Ops;
+/// Elements handled per iteration of the auto-vectorized fallback. Four independent
+/// discount factors, so the compiler has something to widen even without intrinsics.
+const AUTOVEC_CHUNK: usize = 4;
 
-#[cfg(target_arch = "x86_64")]
-impl SimdOps for Avx2Ops {
-    #[target_feature(enable = "avx2,fma")]
-    unsafe fn process_npv_chunk(
-        base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-    ) -> (f64, f64) {
-        use std::arch::x86_64::*;
-
-        // Prefetch next chunk for better memory performance
-        if start_idx + 8 < values.len() {
-            _mm_prefetch::<_MM_HINT_T0>(values.as_ptr().add(start_idx + 8) as *const i8);
-        }
-
-        let vec_base = _mm256_set1_pd(base);
-        let vec_power_base = _mm256_set1_pd(power);
-
-        // More efficient power calculation with FMA
-        let vec_base_squared = _mm256_mul_pd(vec_base, vec_base);
-        let vec_base_cubed = _mm256_fmadd_pd(vec_base, vec_base_squared, _mm256_setzero_pd());
-
-        // Set up multipliers more efficiently
-        let vec_mult = _mm256_set_pd(
-            _mm_cvtsd_f64(_mm256_castpd256_pd128(vec_base_cubed)),
-            _mm_cvtsd_f64(_mm256_castpd256_pd128(vec_base_squared)),
-            base,
-            1.0,
-        );
-
-        // Use FMA for power calculation
-        let vec_power = _mm256_mul_pd(vec_power_base, vec_mult);
-
-        // Load values - check if we can use aligned load
-        let vec_values = if (values.as_ptr() as usize + start_idx * 8) % 32 == 0 {
-            _mm256_load_pd(&values[start_idx])
-        } else {
-            _mm256_loadu_pd(&values[start_idx])
-        };
-
-        let vec_result = _mm256_div_pd(vec_values, vec_power);
-
-        // Sum the results
-        let mut result_array = [0.0; 4];
-        _mm256_storeu_pd(result_array.as_mut_ptr(), vec_result);
-        let sum = result_array.iter().sum::<f64>();
-
-        (sum, power * Self::precompute_power_factor(base))
-    }
-
-    #[target_feature(enable = "avx2,fma")]
-    unsafe fn process_npv_deriv_chunk(
-        base: f64,
-        inv_base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-        start_index: usize,
-    ) -> (f64, f64, f64) {
-        use std::arch::x86_64::*;
-
-        // Prefetch next chunk
-        if start_idx + 8 < values.len() {
-            _mm_prefetch::<_MM_HINT_T0>(values.as_ptr().add(start_idx + 8) as *const i8);
-        }
-
-        let vec_base = _mm256_set1_pd(base);
-        let vec_power_base = _mm256_set1_pd(power);
-        let vec_inv_base = _mm256_set1_pd(inv_base);
-
-        // More efficient power calculation with FMA
-        let vec_base_squared = _mm256_mul_pd(vec_base, vec_base);
-        let vec_base_cubed = _mm256_fmadd_pd(vec_base, vec_base_squared, _mm256_setzero_pd());
-
-        // Set up multipliers
-        let vec_mult = _mm256_set_pd(
-            _mm_cvtsd_f64(_mm256_castpd256_pd128(vec_base_cubed)),
-            _mm_cvtsd_f64(_mm256_castpd256_pd128(vec_base_squared)),
-            base,
-            1.0,
-        );
-
-        // Use FMA where applicable
-        let vec_power = _mm256_mul_pd(vec_power_base, vec_mult);
-
-        // Optimized value loading
-        let vec_values = if (values.as_ptr() as usize + start_idx * 8) % 32 == 0 {
-            _mm256_load_pd(&values[start_idx])
-        } else {
-            _mm256_loadu_pd(&values[start_idx])
-        };
-
-        // Create index vector for derivative - using direct set rather than repeated conversions
-        let offset = start_index + start_idx;
-        let vec_indices = _mm256_set_pd(
-            (offset + 3) as f64,
-            (offset + 2) as f64,
-            (offset + 1) as f64,
-            offset as f64,
-        );
-
-        // Calculate NPV terms
-        let vec_term = _mm256_div_pd(vec_values, vec_power);
-
-        // Use FMA to optimize derivative calculation
-        let vec_deriv = _mm256_mul_pd(vec_indices, vec_term);
-        let vec_deriv = _mm256_fnmadd_pd(vec_deriv, vec_inv_base, _mm256_setzero_pd());
-
-        // Store results
-        let mut term_array = [0.0; 4];
-        let mut deriv_array = [0.0; 4];
-        _mm256_storeu_pd(term_array.as_mut_ptr(), vec_term);
-        _mm256_storeu_pd(deriv_array.as_mut_ptr(), vec_deriv);
-
-        let sum = term_array.iter().sum::<f64>();
-        let deriv = deriv_array.iter().sum::<f64>();
-
-        (sum, deriv, power * Self::precompute_power_factor(base))
-    }
-
-    fn chunk_size() -> usize {
-        4
-    }
-
-    #[target_feature(enable = "avx2,fma")]
-    unsafe fn precompute_power_factor(base: f64) -> f64 {
-        use std::arch::x86_64::*;
-        let vec_base = _mm256_set1_pd(base);
-        let vec_base_squared = _mm256_mul_pd(vec_base, vec_base);
-        let vec_base4 = _mm256_fmadd_pd(vec_base_squared, vec_base_squared, _mm256_setzero_pd());
-        _mm_cvtsd_f64(_mm256_castpd256_pd128(vec_base4))
-    }
-
-    fn is_supported() -> bool {
-        is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")
-    }
-}
-
-/// Auto-vectorized implementation
-struct AutoVecOps;
-
-impl SimdOps for AutoVecOps {
-    unsafe fn process_npv_chunk(
-        base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-    ) -> (f64, f64) {
-        // Using a pattern that's friendly for auto-vectorization
-        const CHUNK: usize = 4;
-        let mut accum = 0.0;
-        let mut powers = [0.0; CHUNK];
-
-        // Initialize powers for this chunk
-        powers[0] = power;
-        for i in 1..CHUNK {
-            powers[i] = powers[i - 1] * base;
-        }
-
-        // Process values
-        for i in 0..CHUNK {
-            accum += values[start_idx + i] / powers[i];
-        }
-
-        // Return sum and updated power for next chunk
-        (accum, powers[CHUNK - 1] * base)
-    }
-
-    unsafe fn process_npv_deriv_chunk(
-        base: f64,
-        inv_base: f64,
-        values: &[f64],
-        start_idx: usize,
-        power: f64,
-        start_index: usize,
-    ) -> (f64, f64, f64) {
-        const CHUNK: usize = 4;
-        let mut sum_accum = 0.0;
-        let mut deriv_accum = 0.0;
-        let mut powers = [0.0; CHUNK];
-
-        // Initialize powers for this chunk
-        powers[0] = power;
-        for i in 1..CHUNK {
-            powers[i] = powers[i - 1] * base;
-        }
-
-        // Process values - compute sum and derivative
-        for i in 0..CHUNK {
-            let idx = start_idx + i;
-            let term = values[idx] / powers[i];
-            sum_accum += term;
-            deriv_accum -= (start_index + idx) as f64 * term * inv_base;
-        }
-
-        // Return sum, derivative and updated power for next chunk
-        (sum_accum, deriv_accum, powers[CHUNK - 1] * base)
-    }
-
-    fn chunk_size() -> usize {
-        4
-    }
-
-    unsafe fn precompute_power_factor(base: f64) -> f64 {
-        base * base * base * base // base^4
-    }
-
-    fn is_supported() -> bool {
-        true
-    }
-}
-
-/// Generic NPV calculation using SIMD operations
-#[inline]
-unsafe fn npv_simd_generic<S: SimdOps>(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
+/// NPV without intrinsics: the fallback for slices too short to pay for a SIMD kernel, and
+/// the reference the kernel tests are checked against.
+///
+/// The chunking is what makes it worth writing this way rather than as a flat loop: the
+/// four powers of `base` are built up front so the divisions inside a chunk do not depend
+/// on each other. It also fixes the summation order, which is why the kernels are compared
+/// against this rather than the other way round.
+fn npv_autovec(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
     let mut sum = 0.0;
     let mut power = if start_from_zero {
         1.0
@@ -406,18 +30,23 @@ unsafe fn npv_simd_generic<S: SimdOps>(base: f64, values: &[f64], start_from_zer
         base
     };
 
-    let chunk_size = S::chunk_size();
-    let simd_limit = (values.len() / chunk_size) * chunk_size;
+    let mut chunks = values.chunks_exact(AUTOVEC_CHUNK);
+    for chunk in &mut chunks {
+        let mut powers = [power; AUTOVEC_CHUNK];
+        for i in 1..AUTOVEC_CHUNK {
+            powers[i] = powers[i - 1] * base;
+        }
 
-    // Process chunks
-    for i in (0..simd_limit).step_by(chunk_size) {
-        let (chunk_sum, new_power) = S::process_npv_chunk(base, values, i, power);
-        sum += chunk_sum;
-        power = new_power;
+        let mut accum = 0.0;
+        for (&value, &p) in chunk.iter().zip(powers.iter()) {
+            accum += value / p;
+        }
+
+        sum += accum;
+        power = powers[AUTOVEC_CHUNK - 1] * base;
     }
 
-    // Process remaining elements
-    for &value in &values[simd_limit..] {
+    for &value in chunks.remainder() {
         sum += value / power;
         power *= base;
     }
@@ -425,13 +54,10 @@ unsafe fn npv_simd_generic<S: SimdOps>(base: f64, values: &[f64], start_from_zer
     sum
 }
 
-/// Generic NPV with derivative calculation
-#[inline]
-unsafe fn npv_with_deriv_generic<S: SimdOps>(
-    rate: f64,
-    values: &[f64],
-    start_index: usize,
-) -> (f64, f64) {
+/// NPV and its derivative without intrinsics. Same role and same chunking as
+/// [`npv_autovec`]; `start_index` feeds the derivative's index weights, while the discount
+/// exponent always starts at 1 because the caller has already handled element 0.
+fn npv_with_deriv_autovec(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
     let base = 1.0 + rate;
     let inv_base = 1.0 / base;
 
@@ -439,26 +65,32 @@ unsafe fn npv_with_deriv_generic<S: SimdOps>(
     let mut deriv = 0.0;
     let mut power = base;
 
-    let chunk_size = S::chunk_size();
-    let simd_limit = (values.len() / chunk_size) * chunk_size;
+    let mut chunks = values.chunks_exact(AUTOVEC_CHUNK);
+    for (c, chunk) in (&mut chunks).enumerate() {
+        let mut powers = [power; AUTOVEC_CHUNK];
+        for i in 1..AUTOVEC_CHUNK {
+            powers[i] = powers[i - 1] * base;
+        }
 
-    // Process chunks
-    for chunk_idx in 0..(simd_limit / chunk_size) {
-        let idx = chunk_idx * chunk_size;
-        let (chunk_sum, chunk_deriv, new_power) =
-            S::process_npv_deriv_chunk(base, inv_base, values, idx, power, start_index);
+        let mut sum_accum = 0.0;
+        let mut deriv_accum = 0.0;
+        let offset = start_index + c * AUTOVEC_CHUNK;
+        for (i, (&value, &p)) in chunk.iter().zip(powers.iter()).enumerate() {
+            let term = value / p;
+            sum_accum += term;
+            deriv_accum -= (offset + i) as f64 * term * inv_base;
+        }
 
-        sum += chunk_sum;
-        deriv += chunk_deriv;
-        power = new_power;
+        sum += sum_accum;
+        deriv += deriv_accum;
+        power = powers[AUTOVEC_CHUNK - 1] * base;
     }
 
-    // Process remaining elements
-    for (i, &value) in values[simd_limit..].iter().enumerate() {
+    let done = values.len() - chunks.remainder().len();
+    for (i, &value) in chunks.remainder().iter().enumerate() {
         let term = value / power;
         sum += term;
-        let index = start_index + simd_limit + i;
-        deriv -= (index as f64) * term * inv_base;
+        deriv -= (start_index + done + i) as f64 * term * inv_base;
         power *= base;
     }
 
@@ -487,6 +119,7 @@ unsafe fn hsum_pd(v: std::arch::x86_64::__m256d) -> f64 {
 }
 
 /// `acc + a * b` for the AVX2+FMA tier: a single fused instruction.
+#[cfg(target_arch = "x86_64")]
 macro_rules! madd_fma {
     ($a:expr, $b:expr, $acc:expr) => {
         _mm256_fmadd_pd($a, $b, $acc)
@@ -495,6 +128,7 @@ macro_rules! madd_fma {
 
 /// `acc + a * b` for the plain AVX tier, which has no FMA. Rounds twice rather than
 /// once, so results can differ from the AVX2 tier in the last ulp — as they already did.
+#[cfg(target_arch = "x86_64")]
 macro_rules! madd_mul_add {
     ($a:expr, $b:expr, $acc:expr) => {
         _mm256_add_pd(_mm256_mul_pd($a, $b), $acc)
@@ -506,15 +140,15 @@ macro_rules! madd_mul_add {
 /// AVX and AVX2+FMA differ only in how a multiply-accumulate is spelled, so both tiers
 /// are generated from this one definition instead of two copies that can drift apart.
 /// Every other intrinsic used here is AVX-level.
+#[cfg(target_arch = "x86_64")]
 macro_rules! define_simd256_kernels {
     ($npv:ident, $npv_deriv:ident, $feature:literal, $madd:ident) => {
         /// NPV over the whole slice in one pass.
         ///
-        /// Replaces the per-chunk `SimdOps` path, which recomputed `[1, b, b², b³]` and `b⁴` for
+        /// Replaces the per-chunk path this file used to carry, which recomputed `[1, b, b², b³]` and `b⁴` for
         /// every four elements, divided by the discount factor, and round-tripped the result
         /// through the stack to sum it. Here the powers of `1/base` are carried in registers, the
         /// division becomes a multiply, and there is exactly one horizontal reduction at the end.
-        #[cfg(target_arch = "x86_64")]
         #[target_feature(enable = $feature)]
         unsafe fn $npv(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
             use std::arch::x86_64::*;
@@ -575,7 +209,6 @@ macro_rules! define_simd256_kernels {
         /// Same treatment as [`npv_simd_avx2`], plus: the index vector is carried and incremented
         /// rather than rebuilt from four `usize -> f64` conversions per chunk, and the `-1/base`
         /// factor common to every derivative term is applied once at the end instead of per element.
-        #[cfg(target_arch = "x86_64")]
         #[target_feature(enable = $feature)]
         unsafe fn $npv_deriv(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
             use std::arch::x86_64::*;
@@ -586,7 +219,7 @@ macro_rules! define_simd256_kernels {
             let ib3 = ib2 * inv_base;
             let ib4 = ib2 * ib2;
 
-            // Matches `npv_with_deriv_generic`: the discount exponent starts at 1 whatever
+            // Matches `npv_with_deriv_autovec`: the discount exponent starts at 1 whatever
             // `start_index` is — the caller has already handled element 0 — while `start_index`
             // only feeds the derivative's index weights. The two coincide for the production
             // call, which passes `&values[1..]` with `start_index == 1`.
@@ -654,7 +287,9 @@ macro_rules! define_simd256_kernels {
     };
 }
 
+#[cfg(target_arch = "x86_64")]
 define_simd256_kernels!(npv_simd_avx2, npv_with_deriv_avx2, "avx2,fma", madd_fma);
+#[cfg(target_arch = "x86_64")]
 define_simd256_kernels!(npv_simd_avx, npv_with_deriv_avx, "avx", madd_mul_add);
 
 /// Lanes consumed per iteration of the NEON kernels. A NEON vector holds two doubles, so
@@ -679,7 +314,7 @@ const NEON_DERIV_MIN_LEN: usize = NEON_BLOCK + 1;
 
 /// NPV over the whole slice in one pass.
 ///
-/// Replaces the per-chunk `SimdOps` path, which rebuilt `[1, base]` and `base²` for every
+/// Replaces the per-chunk path this file used to carry, which rebuilt `[1, base]` and `base²` for every
 /// two elements, divided by the discount factor, and round-tripped the pair through the
 /// stack to sum it — two lanes of work per call, with a serial dependency between calls.
 /// Here the powers of `1/base` are carried in registers across four independent chains, the
@@ -762,10 +397,6 @@ unsafe fn npv_simd_neon(base: f64, values: &[f64], start_from_zero: bool) -> f64
     sum
 }
 
-fn npv_autovec(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
-    unsafe { npv_simd_generic::<AutoVecOps>(base, values, start_from_zero) }
-}
-
 /// NPV and its derivative over the whole slice in one pass.
 ///
 /// Same treatment as [`npv_simd_neon`], plus: the index vector is carried and incremented
@@ -782,7 +413,7 @@ unsafe fn npv_with_deriv_neon(rate: f64, values: &[f64], start_index: usize) -> 
     let ib4 = ib2 * ib2;
     let ib8 = ib4 * ib4;
 
-    // Matches `npv_with_deriv_generic`: the discount exponent starts at 1 whatever
+    // Matches `npv_with_deriv_autovec`: the discount exponent starts at 1 whatever
     // `start_index` is — the caller has already handled element 0 — while `start_index`
     // only feeds the derivative's index weights. The two coincide for the production
     // call, which passes `&values[1..]` with `start_index == 1`.
@@ -881,10 +512,6 @@ unsafe fn npv_with_deriv_neon(rate: f64, values: &[f64], start_index: usize) -> 
     (sum, -weighted * inv_base)
 }
 
-fn npv_with_deriv_autovec(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
-    unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, values, start_index) }
-}
-
 /// SIMD tier selected once per process from CPU support + the `ENABLE_*` overrides.
 ///
 /// Neither the CPUID probe nor the environment changes during a run, so resolving this
@@ -902,12 +529,9 @@ enum SimdTier {
 #[cfg(target_arch = "x86_64")]
 fn simd_tier() -> SimdTier {
     static TIER: std::sync::LazyLock<SimdTier> = std::sync::LazyLock::new(|| {
-        if std::env::var("ENABLE_AVX2").map(|x| x == "1").unwrap_or(true) && Avx2Ops::is_supported()
-        {
+        if std::env::var("ENABLE_AVX2").map(|x| x == "1").unwrap_or(true) && avx2_supported() {
             SimdTier::Avx2
-        } else if std::env::var("ENABLE_AVX").map(|x| x == "1").unwrap_or(true)
-            && AvxOps::is_supported()
-        {
+        } else if std::env::var("ENABLE_AVX").map(|x| x == "1").unwrap_or(true) && avx_supported() {
             SimdTier::Avx
         } else {
             SimdTier::None
@@ -1013,17 +637,6 @@ pub fn npv_with_deriv_simd(rate: f64, values: &[f64]) -> (f64, f64) {
 mod tests {
     use super::*;
 
-    fn test_npv_implementation<S: SimdOps>(values: &[f64], rate: f64) -> f64 {
-        unsafe {
-            let base = 1.0 + rate;
-            npv_simd_generic::<S>(base, values, true)
-        }
-    }
-
-    fn test_npv_deriv_implementation<S: SimdOps>(values: &[f64], rate: f64) -> (f64, f64) {
-        unsafe { npv_with_deriv_generic::<S>(rate, values, 0) }
-    }
-
     fn get_reference_npv(values: &[f64], rate: f64) -> f64 {
         let base = 1.0 + rate;
         let mut sum = 0.0;
@@ -1053,9 +666,10 @@ mod tests {
         (sum, deriv)
     }
 
-    #[test]
-    fn test_simd_implementations_boundary_cases() {
-        let test_cases = vec![
+    /// Lengths that straddle the fallback's 4-element chunk and the SIMD dispatch
+    /// thresholds above it.
+    fn boundary_cases() -> Vec<Vec<f64>> {
+        vec![
             vec![],                                                      // empty
             vec![100.0],                                                 // single value
             vec![100.0, -30.0],                                          // less than chunk size
@@ -1063,233 +677,80 @@ mod tests {
             vec![100.0, -30.0, 20.0, 15.0],                              // exact chunk size (4)
             vec![100.0, -30.0, 20.0, 15.0, 5.0],                         // chunk size + 1
             vec![100.0, -30.0, 20.0, 15.0, 5.0, -10.0, 25.0, 8.0],       // exactly 8
-            vec![100.0, -30.0, 20.0, 15.0, 5.0, -10.0, 25.0, 8.0, 12.0], // > 8 (SIMD threshold)
-        ];
-
-        let rate = 0.05;
-
-        for values in &test_cases {
-            let ref_npv = get_reference_npv(values, rate);
-            let (ref_sum, ref_deriv) = get_reference_npv_deriv(values, rate, 0);
-
-            // Test AutoVecOps (always available)
-            {
-                let auto_npv = test_npv_implementation::<AutoVecOps>(values, rate);
-                assert!(
-                    (auto_npv - ref_npv).abs() < 1e-6,
-                    "AutoVecOps NPV failed for len {}: got {}, expected {}",
-                    values.len(),
-                    auto_npv,
-                    ref_npv
-                );
-
-                let (auto_sum, auto_deriv) =
-                    test_npv_deriv_implementation::<AutoVecOps>(values, rate);
-                assert!(
-                    (auto_sum - ref_sum).abs() < 1e-6 && (auto_deriv - ref_deriv).abs() < 1e-6,
-                    "AutoVecOps NPV+deriv failed for len {}",
-                    values.len()
-                );
-            }
-
-            // Test AVX implementation if supported
-            #[cfg(target_arch = "x86_64")]
-            if AvxOps::is_supported() {
-                let avx_npv = test_npv_implementation::<AvxOps>(values, rate);
-                assert!(
-                    (avx_npv - ref_npv).abs() < 1e-6,
-                    "AVX NPV failed for len {}: got {}, expected {}",
-                    values.len(),
-                    avx_npv,
-                    ref_npv
-                );
-
-                let (avx_sum, avx_deriv) = test_npv_deriv_implementation::<AvxOps>(values, rate);
-                assert!(
-                    (avx_sum - ref_sum).abs() < 1e-6 && (avx_deriv - ref_deriv).abs() < 1e-6,
-                    "AVX NPV+deriv failed for len {}",
-                    values.len()
-                );
-            }
-
-            // Test AVX2+FMA implementation if supported
-            #[cfg(target_arch = "x86_64")]
-            if Avx2Ops::is_supported() {
-                let avx2_npv = test_npv_implementation::<Avx2Ops>(values, rate);
-                assert!(
-                    (avx2_npv - ref_npv).abs() < 1e-6,
-                    "AVX2 NPV failed for len {}: got {}, expected {}",
-                    values.len(),
-                    avx2_npv,
-                    ref_npv
-                );
-
-                let (avx2_sum, avx2_deriv) = test_npv_deriv_implementation::<Avx2Ops>(values, rate);
-                assert!(
-                    (avx2_sum - ref_sum).abs() < 1e-6 && (avx2_deriv - ref_deriv).abs() < 1e-6,
-                    "AVX2 NPV+deriv failed for len {}",
-                    values.len()
-                );
-            }
-
-            // Test NEON implementation on ARM
-            #[cfg(target_arch = "aarch64")]
-            {
-                let neon_npv = unsafe { npv_simd_neon(1.0 + rate, values, true) };
-                assert!(
-                    (neon_npv - ref_npv).abs() < 1e-6,
-                    "NEON NPV failed for len {}: got {}, expected {}",
-                    values.len(),
-                    neon_npv,
-                    ref_npv
-                );
-
-                let (neon_sum, neon_deriv) = unsafe { npv_with_deriv_neon(rate, values, 0) };
-                assert!(
-                    (neon_sum - ref_sum).abs() < 1e-6 && (neon_deriv - ref_deriv).abs() < 1e-6,
-                    "NEON NPV+deriv failed for len {}",
-                    values.len()
-                );
-            }
-        }
+            vec![100.0, -30.0, 20.0, 15.0, 5.0, -10.0, 25.0, 8.0, 12.0], // > 8
+        ]
     }
 
+    /// The auto-vectorized fallback against the scalar reference. This is the base of the
+    /// chain: the per-architecture tests below check every SIMD kernel against the
+    /// fallback, over every length from 0 to 40.
     #[test]
-    fn test_simd_implementations_non_zero_start() {
-        let test_cases = vec![
-            vec![],                                                      // empty
-            vec![100.0],                                                 // single value
-            vec![100.0, -30.0],                                          // less than chunk size
-            vec![100.0, -30.0, 20.0],                                    // less than chunk size
-            vec![100.0, -30.0, 20.0, 15.0],                              // exact chunk size (4)
-            vec![100.0, -30.0, 20.0, 15.0, 5.0],                         // chunk size + 1
-            vec![100.0, -30.0, 20.0, 15.0, 5.0, -10.0, 25.0, 8.0],       // exactly 8
-            vec![100.0, -30.0, 20.0, 15.0, 5.0, -10.0, 25.0, 8.0, 12.0], // > 8 (SIMD threshold)
-        ];
-
+    fn test_autovec_boundary_cases() {
         let rate = 0.05;
 
-        for values in &test_cases {
-            // Test with start_from_zero = false for each implementation
-            let base = 1.0 + rate;
-            let mut sum = 0.0;
-            let mut power = base; // Start from base instead of 1.0
-            for &val in values {
-                sum += val / power;
-                power *= base;
-            }
-            let ref_npv = sum;
+        for values in boundary_cases() {
+            let ref_npv = get_reference_npv(&values, rate);
+            let (ref_sum, ref_deriv) = get_reference_npv_deriv(&values, rate, 0);
 
-            // Test AutoVecOps
-            let auto_npv = unsafe { npv_simd_generic::<AutoVecOps>(base, values, false) };
+            let auto_npv = npv_autovec(1.0 + rate, &values, true);
             assert!(
                 (auto_npv - ref_npv).abs() < 1e-6,
-                "AutoVecOps NPV(non-zero start) failed for len {}: got {}, expected {}",
+                "autovec NPV failed for len {}: got {}, expected {}",
                 values.len(),
                 auto_npv,
                 ref_npv
             );
 
-            // Test other implementations...
-            #[cfg(target_arch = "x86_64")]
-            if AvxOps::is_supported() {
-                let avx_npv = unsafe { npv_simd_generic::<AvxOps>(base, values, false) };
-                assert!(
-                    (avx_npv - ref_npv).abs() < 1e-6,
-                    "AVX NPV(non-zero start) failed for len {}: got {}, expected {}",
-                    values.len(),
-                    avx_npv,
-                    ref_npv
-                );
-            }
-
-            #[cfg(target_arch = "x86_64")]
-            if Avx2Ops::is_supported() {
-                let avx2_npv = unsafe { npv_simd_generic::<Avx2Ops>(base, values, false) };
-                assert!(
-                    (avx2_npv - ref_npv).abs() < 1e-6,
-                    "AVX2 NPV(non-zero start) failed for len {}: got {}, expected {}",
-                    values.len(),
-                    avx2_npv,
-                    ref_npv
-                );
-            }
-
-            #[cfg(target_arch = "aarch64")]
-            {
-                let neon_npv = unsafe { npv_simd_neon(base, values, false) };
-                assert!(
-                    (neon_npv - ref_npv).abs() < 1e-6,
-                    "NEON NPV(non-zero start) failed for len {}: got {}, expected {}",
-                    values.len(),
-                    neon_npv,
-                    ref_npv
-                );
-            }
+            let (auto_sum, auto_deriv) = npv_with_deriv_autovec(rate, &values, 0);
+            assert!(
+                (auto_sum - ref_sum).abs() < 1e-6 && (auto_deriv - ref_deriv).abs() < 1e-6,
+                "autovec NPV+deriv failed for len {}",
+                values.len()
+            );
         }
     }
 
+    /// `start_from_zero = false`: the first value is discounted one period rather than none.
     #[test]
-    fn test_simd_implementations_with_start_index() {
-        let test_cases = vec![
-            vec![],                                                      // empty
-            vec![100.0],                                                 // single value
-            vec![100.0, -30.0],                                          // less than chunk size
-            vec![100.0, -30.0, 20.0],                                    // less than chunk size
-            vec![100.0, -30.0, 20.0, 15.0],                              // exact chunk size (4)
-            vec![100.0, -30.0, 20.0, 15.0, 5.0],                         // chunk size + 1
-            vec![100.0, -30.0, 20.0, 15.0, 5.0, -10.0, 25.0, 8.0],       // exactly 8
-            vec![100.0, -30.0, 20.0, 15.0, 5.0, -10.0, 25.0, 8.0, 12.0], // > 8 (SIMD threshold)
-        ];
+    fn test_autovec_non_zero_start() {
+        let rate = 0.05;
+        let base = 1.0 + rate;
 
+        for values in boundary_cases() {
+            let mut ref_npv = 0.0;
+            let mut power = base; // Start from base instead of 1.0
+            for &val in &values {
+                ref_npv += val / power;
+                power *= base;
+            }
+
+            let auto_npv = npv_autovec(base, &values, false);
+            assert!(
+                (auto_npv - ref_npv).abs() < 1e-6,
+                "autovec NPV(non-zero start) failed for len {}: got {}, expected {}",
+                values.len(),
+                auto_npv,
+                ref_npv
+            );
+        }
+    }
+
+    /// A non-zero `start_index` shifts the derivative's index weights without touching the
+    /// discount exponents — the production call passes `&values[1..]` with `start_index == 1`.
+    #[test]
+    fn test_autovec_with_start_index() {
         let rate = 0.05;
         let start_index = 1;
 
-        for values in &test_cases {
-            let (ref_sum, ref_deriv) = get_reference_npv_deriv(values, rate, start_index);
+        for values in boundary_cases() {
+            let (ref_sum, ref_deriv) = get_reference_npv_deriv(&values, rate, start_index);
 
-            // Test all implementations with start_index = 1
-            let (auto_sum, auto_deriv) =
-                unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, values, start_index) };
+            let (auto_sum, auto_deriv) = npv_with_deriv_autovec(rate, &values, start_index);
             assert!(
                 (auto_sum - ref_sum).abs() < 1e-6 && (auto_deriv - ref_deriv).abs() < 1e-6,
-                "AutoVecOps NPV+deriv with start_index failed for len {}",
+                "autovec NPV+deriv with start_index failed for len {}",
                 values.len()
             );
-
-            // Test other implementations...
-            #[cfg(target_arch = "x86_64")]
-            if AvxOps::is_supported() {
-                let (avx_sum, avx_deriv) =
-                    unsafe { npv_with_deriv_generic::<AvxOps>(rate, values, start_index) };
-                assert!(
-                    (avx_sum - ref_sum).abs() < 1e-6 && (avx_deriv - ref_deriv).abs() < 1e-6,
-                    "AVX NPV+deriv with start_index failed for len {}",
-                    values.len()
-                );
-            }
-
-            #[cfg(target_arch = "x86_64")]
-            if Avx2Ops::is_supported() {
-                let (avx2_sum, avx2_deriv) =
-                    unsafe { npv_with_deriv_generic::<Avx2Ops>(rate, values, start_index) };
-                assert!(
-                    (avx2_sum - ref_sum).abs() < 1e-6 && (avx2_deriv - ref_deriv).abs() < 1e-6,
-                    "AVX2 NPV+deriv with start_index failed for len {}",
-                    values.len(),
-                );
-            }
-
-            #[cfg(target_arch = "aarch64")]
-            {
-                let (neon_sum, neon_deriv) =
-                    unsafe { npv_with_deriv_neon(rate, values, start_index) };
-                assert!(
-                    (neon_sum - ref_sum).abs() < 1e-6 && (neon_deriv - ref_deriv).abs() < 1e-6,
-                    "NEON NPV+deriv with start_index failed for len {}",
-                    values.len(),
-                );
-            }
         }
     }
 
@@ -1377,7 +838,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_avx2_kernels_match_reference() {
-        if !Avx2Ops::is_supported() {
+        if !avx2_supported() {
             eprintln!("AVX2 not supported on this CPU, skipping");
             return;
         }
@@ -1400,8 +861,7 @@ mod tests {
 
                 for &start_from_zero in &[true, false] {
                     let got = unsafe { npv_simd_avx2(base, &values, start_from_zero) };
-                    let want =
-                        unsafe { npv_simd_generic::<AutoVecOps>(base, &values, start_from_zero) };
+                    let want = npv_autovec(base, &values, start_from_zero);
                     let tol = 1e-9 * want.abs().max(1.0);
                     assert!(
                         (got - want).abs() <= tol,
@@ -1412,8 +872,7 @@ mod tests {
                 for &start_index in &[0usize, 1, 5] {
                     let (got_sum, got_deriv) =
                         unsafe { npv_with_deriv_avx2(rate, &values, start_index) };
-                    let (want_sum, want_deriv) =
-                        unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, &values, start_index) };
+                    let (want_sum, want_deriv) = npv_with_deriv_autovec(rate, &values, start_index);
 
                     let sum_tol = 1e-9 * want_sum.abs().max(1.0);
                     let deriv_tol = 1e-9 * want_deriv.abs().max(1.0);
@@ -1436,7 +895,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_avx_kernels_match_reference() {
-        if !AvxOps::is_supported() {
+        if !avx_supported() {
             eprintln!("AVX not supported on this CPU, skipping");
             return;
         }
@@ -1459,8 +918,7 @@ mod tests {
 
                 for &start_from_zero in &[true, false] {
                     let got = unsafe { npv_simd_avx(base, &values, start_from_zero) };
-                    let want =
-                        unsafe { npv_simd_generic::<AutoVecOps>(base, &values, start_from_zero) };
+                    let want = npv_autovec(base, &values, start_from_zero);
                     let tol = 1e-9 * want.abs().max(1.0);
                     assert!(
                         (got - want).abs() <= tol,
@@ -1471,8 +929,7 @@ mod tests {
                 for &start_index in &[0usize, 1, 5] {
                     let (got_sum, got_deriv) =
                         unsafe { npv_with_deriv_avx(rate, &values, start_index) };
-                    let (want_sum, want_deriv) =
-                        unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, &values, start_index) };
+                    let (want_sum, want_deriv) = npv_with_deriv_autovec(rate, &values, start_index);
 
                     let sum_tol = 1e-9 * want_sum.abs().max(1.0);
                     let deriv_tol = 1e-9 * want_deriv.abs().max(1.0);
@@ -1514,8 +971,7 @@ mod tests {
 
                 for &start_from_zero in &[true, false] {
                     let got = unsafe { npv_simd_neon(base, &values, start_from_zero) };
-                    let want =
-                        unsafe { npv_simd_generic::<AutoVecOps>(base, &values, start_from_zero) };
+                    let want = npv_autovec(base, &values, start_from_zero);
                     let tol = 1e-9 * want.abs().max(1.0);
                     assert!(
                         (got - want).abs() <= tol,
@@ -1526,8 +982,7 @@ mod tests {
                 for &start_index in &[0usize, 1, 5] {
                     let (got_sum, got_deriv) =
                         unsafe { npv_with_deriv_neon(rate, &values, start_index) };
-                    let (want_sum, want_deriv) =
-                        unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, &values, start_index) };
+                    let (want_sum, want_deriv) = npv_with_deriv_autovec(rate, &values, start_index);
 
                     let sum_tol = 1e-9 * want_sum.abs().max(1.0);
                     let deriv_tol = 1e-9 * want_deriv.abs().max(1.0);
@@ -1587,7 +1042,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_avx2_kernels_long_series_accuracy() {
-        if !Avx2Ops::is_supported() {
+        if !avx2_supported() {
             return;
         }
 

--- a/src/core/periodic/npv.rs
+++ b/src/core/periodic/npv.rs
@@ -569,21 +569,15 @@ unsafe fn npv_with_deriv_generic<S: SimdOps>(
     (sum, deriv)
 }
 
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx")]
-unsafe fn npv_simd_avx(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
-    npv_simd_generic::<AvxOps>(base, values, start_from_zero)
-}
-
-/// Lanes consumed per iteration of the AVX2 kernels: two 4-wide vectors, so the discount
+/// Lanes consumed per iteration of the 256-bit kernels: two 4-wide vectors, so the discount
 /// factor and accumulator chains are independent and the loop is not latency-bound.
 #[cfg(target_arch = "x86_64")]
-const AVX2_BLOCK: usize = 8;
+const SIMD256_BLOCK: usize = 8;
 
-/// Shortest slice worth entering the AVX2 kernel for, rather than the auto-vectorized
+/// Shortest slice worth entering a 256-bit kernel for, rather than the auto-vectorized
 /// fallback. Measured, not assumed — see `benches/npv_kernel.rs`.
 #[cfg(target_arch = "x86_64")]
-const AVX2_MIN_LEN: usize = 6;
+const SIMD256_MIN_LEN: usize = 6;
 
 /// Horizontal sum of a 4-wide vector. Done once at the end of a kernel, never per chunk.
 #[cfg(target_arch = "x86_64")]
@@ -596,67 +590,176 @@ unsafe fn hsum_pd(v: std::arch::x86_64::__m256d) -> f64 {
     _mm_cvtsd_f64(_mm_add_sd(s, _mm_unpackhi_pd(s, s)))
 }
 
-/// NPV over the whole slice in one pass.
-///
-/// Replaces the per-chunk `SimdOps` path, which recomputed `[1, b, b², b³]` and `b⁴` for
-/// every four elements, divided by the discount factor, and round-tripped the result
-/// through the stack to sum it. Here the powers of `1/base` are carried in registers, the
-/// division becomes a multiply, and there is exactly one horizontal reduction at the end.
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx2,fma")]
-unsafe fn npv_simd_avx2(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
-    use std::arch::x86_64::*;
-
-    let inv_base = 1.0 / base;
-    let ib2 = inv_base * inv_base;
-    let ib3 = ib2 * inv_base;
-    let ib4 = ib2 * ib2;
-
-    // discount factor of the first element: base^0 or base^-1
-    let p0 = if start_from_zero {
-        1.0
-    } else {
-        inv_base
+/// `acc + a * b` for the AVX2+FMA tier: a single fused instruction.
+macro_rules! madd_fma {
+    ($a:expr, $b:expr, $acc:expr) => {
+        _mm256_fmadd_pd($a, $b, $acc)
     };
-
-    let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
-    let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
-    let step = _mm256_set1_pd(ib4 * ib4);
-
-    let mut acc_lo = _mm256_setzero_pd();
-    let mut acc_hi = _mm256_setzero_pd();
-
-    let ptr = values.as_ptr();
-    let blocks = values.len() / AVX2_BLOCK;
-
-    for k in 0..blocks {
-        let i = k * AVX2_BLOCK;
-        acc_lo = _mm256_fmadd_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
-        acc_hi = _mm256_fmadd_pd(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi, acc_hi);
-        pow_lo = _mm256_mul_pd(pow_lo, step);
-        pow_hi = _mm256_mul_pd(pow_hi, step);
-    }
-
-    // A remainder of 4 or more is still worth a vector step; only the last 0-3 go scalar.
-    let mut i = blocks * AVX2_BLOCK;
-    if values.len() - i >= 4 {
-        acc_lo = _mm256_fmadd_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
-        pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
-        i += 4;
-    }
-
-    let mut sum = hsum_pd(_mm256_add_pd(acc_lo, acc_hi));
-
-    // lane 0 of pow_lo is the discount factor of the next unprocessed element
-    let mut power = _mm256_cvtsd_f64(pow_lo);
-    while i < values.len() {
-        sum += *ptr.add(i) * power;
-        power *= inv_base;
-        i += 1;
-    }
-
-    sum
 }
+
+/// `acc + a * b` for the plain AVX tier, which has no FMA. Rounds twice rather than
+/// once, so results can differ from the AVX2 tier in the last ulp — as they already did.
+macro_rules! madd_mul_add {
+    ($a:expr, $b:expr, $acc:expr) => {
+        _mm256_add_pd(_mm256_mul_pd($a, $b), $acc)
+    };
+}
+
+/// Emits the 256-bit NPV kernels for one x86 feature tier.
+///
+/// AVX and AVX2+FMA differ only in how a multiply-accumulate is spelled, so both tiers
+/// are generated from this one definition instead of two copies that can drift apart.
+/// Every other intrinsic used here is AVX-level.
+macro_rules! define_simd256_kernels {
+    ($npv:ident, $npv_deriv:ident, $feature:literal, $madd:ident) => {
+        /// NPV over the whole slice in one pass.
+        ///
+        /// Replaces the per-chunk `SimdOps` path, which recomputed `[1, b, b², b³]` and `b⁴` for
+        /// every four elements, divided by the discount factor, and round-tripped the result
+        /// through the stack to sum it. Here the powers of `1/base` are carried in registers, the
+        /// division becomes a multiply, and there is exactly one horizontal reduction at the end.
+        #[cfg(target_arch = "x86_64")]
+        #[target_feature(enable = $feature)]
+        unsafe fn $npv(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
+            use std::arch::x86_64::*;
+
+            let inv_base = 1.0 / base;
+            let ib2 = inv_base * inv_base;
+            let ib3 = ib2 * inv_base;
+            let ib4 = ib2 * ib2;
+
+            // discount factor of the first element: base^0 or base^-1
+            let p0 = if start_from_zero {
+                1.0
+            } else {
+                inv_base
+            };
+
+            let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
+            let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+            let step = _mm256_set1_pd(ib4 * ib4);
+
+            let mut acc_lo = _mm256_setzero_pd();
+            let mut acc_hi = _mm256_setzero_pd();
+
+            let ptr = values.as_ptr();
+            let blocks = values.len() / SIMD256_BLOCK;
+
+            for k in 0..blocks {
+                let i = k * SIMD256_BLOCK;
+                acc_lo = $madd!(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
+                acc_hi = $madd!(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi, acc_hi);
+                pow_lo = _mm256_mul_pd(pow_lo, step);
+                pow_hi = _mm256_mul_pd(pow_hi, step);
+            }
+
+            // A remainder of 4 or more is still worth a vector step; only the last 0-3 go scalar.
+            let mut i = blocks * SIMD256_BLOCK;
+            if values.len() - i >= 4 {
+                acc_lo = $madd!(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
+                pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+                i += 4;
+            }
+
+            let mut sum = hsum_pd(_mm256_add_pd(acc_lo, acc_hi));
+
+            // lane 0 of pow_lo is the discount factor of the next unprocessed element
+            let mut power = _mm256_cvtsd_f64(pow_lo);
+            while i < values.len() {
+                sum += *ptr.add(i) * power;
+                power *= inv_base;
+                i += 1;
+            }
+
+            sum
+        }
+
+        /// NPV and its derivative over the whole slice in one pass.
+        ///
+        /// Same treatment as [`npv_simd_avx2`], plus: the index vector is carried and incremented
+        /// rather than rebuilt from four `usize -> f64` conversions per chunk, and the `-1/base`
+        /// factor common to every derivative term is applied once at the end instead of per element.
+        #[cfg(target_arch = "x86_64")]
+        #[target_feature(enable = $feature)]
+        unsafe fn $npv_deriv(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
+            use std::arch::x86_64::*;
+
+            let base = 1.0 + rate;
+            let inv_base = 1.0 / base;
+            let ib2 = inv_base * inv_base;
+            let ib3 = ib2 * inv_base;
+            let ib4 = ib2 * ib2;
+
+            // Matches `npv_with_deriv_generic`: the discount exponent starts at 1 whatever
+            // `start_index` is — the caller has already handled element 0 — while `start_index`
+            // only feeds the derivative's index weights. The two coincide for the production
+            // call, which passes `&values[1..]` with `start_index == 1`.
+            let p0 = inv_base;
+
+            let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
+            let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+            let step = _mm256_set1_pd(ib4 * ib4);
+
+            let si = start_index as f64;
+            let mut idx_lo = _mm256_set_pd(si + 3.0, si + 2.0, si + 1.0, si);
+            let mut idx_hi = _mm256_add_pd(idx_lo, _mm256_set1_pd(4.0));
+            let idx_step = _mm256_set1_pd(SIMD256_BLOCK as f64);
+
+            let mut sum_lo = _mm256_setzero_pd();
+            let mut sum_hi = _mm256_setzero_pd();
+            // accumulates sum(i * v_i / base^i); scaled by -1/base once the loop is done
+            let mut deriv_lo = _mm256_setzero_pd();
+            let mut deriv_hi = _mm256_setzero_pd();
+
+            let ptr = values.as_ptr();
+            let blocks = values.len() / SIMD256_BLOCK;
+
+            for k in 0..blocks {
+                let i = k * SIMD256_BLOCK;
+
+                let term_lo = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
+                let term_hi = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi);
+
+                sum_lo = _mm256_add_pd(sum_lo, term_lo);
+                sum_hi = _mm256_add_pd(sum_hi, term_hi);
+
+                deriv_lo = $madd!(term_lo, idx_lo, deriv_lo);
+                deriv_hi = $madd!(term_hi, idx_hi, deriv_hi);
+
+                pow_lo = _mm256_mul_pd(pow_lo, step);
+                pow_hi = _mm256_mul_pd(pow_hi, step);
+                idx_lo = _mm256_add_pd(idx_lo, idx_step);
+                idx_hi = _mm256_add_pd(idx_hi, idx_step);
+            }
+
+            let mut i = blocks * SIMD256_BLOCK;
+            if values.len() - i >= 4 {
+                let term = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
+                sum_lo = _mm256_add_pd(sum_lo, term);
+                deriv_lo = $madd!(term, idx_lo, deriv_lo);
+                pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+                i += 4;
+            }
+
+            let mut sum = hsum_pd(_mm256_add_pd(sum_lo, sum_hi));
+            let mut weighted = hsum_pd(_mm256_add_pd(deriv_lo, deriv_hi));
+
+            let mut power = _mm256_cvtsd_f64(pow_lo);
+            while i < values.len() {
+                let term = *ptr.add(i) * power;
+                sum += term;
+                weighted += (start_index + i) as f64 * term;
+                power *= inv_base;
+                i += 1;
+            }
+
+            (sum, -weighted * inv_base)
+        }
+    };
+}
+
+define_simd256_kernels!(npv_simd_avx2, npv_with_deriv_avx2, "avx2,fma", madd_fma);
+define_simd256_kernels!(npv_simd_avx, npv_with_deriv_avx, "avx", madd_mul_add);
 
 #[cfg(target_arch = "aarch64")]
 unsafe fn npv_simd_neon(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
@@ -665,94 +768,6 @@ unsafe fn npv_simd_neon(base: f64, values: &[f64], start_from_zero: bool) -> f64
 
 fn npv_autovec(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
     unsafe { npv_simd_generic::<AutoVecOps>(base, values, start_from_zero) }
-}
-
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx")]
-unsafe fn npv_with_deriv_avx(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
-    npv_with_deriv_generic::<AvxOps>(rate, values, start_index)
-}
-
-/// NPV and its derivative over the whole slice in one pass.
-///
-/// Same treatment as [`npv_simd_avx2`], plus: the index vector is carried and incremented
-/// rather than rebuilt from four `usize -> f64` conversions per chunk, and the `-1/base`
-/// factor common to every derivative term is applied once at the end instead of per element.
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx2,fma")]
-unsafe fn npv_with_deriv_avx2(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
-    use std::arch::x86_64::*;
-
-    let base = 1.0 + rate;
-    let inv_base = 1.0 / base;
-    let ib2 = inv_base * inv_base;
-    let ib3 = ib2 * inv_base;
-    let ib4 = ib2 * ib2;
-
-    // Matches `npv_with_deriv_generic`: the discount exponent starts at 1 whatever
-    // `start_index` is — the caller has already handled element 0 — while `start_index`
-    // only feeds the derivative's index weights. The two coincide for the production
-    // call, which passes `&values[1..]` with `start_index == 1`.
-    let p0 = inv_base;
-
-    let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
-    let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
-    let step = _mm256_set1_pd(ib4 * ib4);
-
-    let si = start_index as f64;
-    let mut idx_lo = _mm256_set_pd(si + 3.0, si + 2.0, si + 1.0, si);
-    let mut idx_hi = _mm256_add_pd(idx_lo, _mm256_set1_pd(4.0));
-    let idx_step = _mm256_set1_pd(AVX2_BLOCK as f64);
-
-    let mut sum_lo = _mm256_setzero_pd();
-    let mut sum_hi = _mm256_setzero_pd();
-    // accumulates sum(i * v_i / base^i); scaled by -1/base once the loop is done
-    let mut deriv_lo = _mm256_setzero_pd();
-    let mut deriv_hi = _mm256_setzero_pd();
-
-    let ptr = values.as_ptr();
-    let blocks = values.len() / AVX2_BLOCK;
-
-    for k in 0..blocks {
-        let i = k * AVX2_BLOCK;
-
-        let term_lo = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
-        let term_hi = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi);
-
-        sum_lo = _mm256_add_pd(sum_lo, term_lo);
-        sum_hi = _mm256_add_pd(sum_hi, term_hi);
-
-        deriv_lo = _mm256_fmadd_pd(term_lo, idx_lo, deriv_lo);
-        deriv_hi = _mm256_fmadd_pd(term_hi, idx_hi, deriv_hi);
-
-        pow_lo = _mm256_mul_pd(pow_lo, step);
-        pow_hi = _mm256_mul_pd(pow_hi, step);
-        idx_lo = _mm256_add_pd(idx_lo, idx_step);
-        idx_hi = _mm256_add_pd(idx_hi, idx_step);
-    }
-
-    let mut i = blocks * AVX2_BLOCK;
-    if values.len() - i >= 4 {
-        let term = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
-        sum_lo = _mm256_add_pd(sum_lo, term);
-        deriv_lo = _mm256_fmadd_pd(term, idx_lo, deriv_lo);
-        pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
-        i += 4;
-    }
-
-    let mut sum = hsum_pd(_mm256_add_pd(sum_lo, sum_hi));
-    let mut weighted = hsum_pd(_mm256_add_pd(deriv_lo, deriv_hi));
-
-    let mut power = _mm256_cvtsd_f64(pow_lo);
-    while i < values.len() {
-        let term = *ptr.add(i) * power;
-        sum += term;
-        weighted += (start_index + i) as f64 * term;
-        power *= inv_base;
-        i += 1;
-    }
-
-    (sum, -weighted * inv_base)
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -816,7 +831,7 @@ pub fn npv_simd(rate: f64, values: &[f64], start_from_zero: Option<bool>) -> f64
 
     #[cfg(target_arch = "x86_64")]
     {
-        if values.len() >= AVX2_MIN_LEN {
+        if values.len() >= SIMD256_MIN_LEN {
             match simd_tier() {
                 SimdTier::Avx2 => return unsafe { npv_simd_avx2(base, values, start_from_zero) },
                 SimdTier::Avx => return unsafe { npv_simd_avx(base, values, start_from_zero) },
@@ -827,6 +842,9 @@ pub fn npv_simd(rate: f64, values: &[f64], start_from_zero: Option<bool>) -> f64
 
     #[cfg(target_arch = "aarch64")]
     {
+        // NEON still runs the original per-chunk kernel, so it keeps the original
+        // threshold. `SIMD256_MIN_LEN` was measured for the rewritten x86 kernels on
+        // x86 hardware and does not transfer; re-measure on ARM before reusing it.
         if neon_enabled() && values.len() > 8 {
             return unsafe { npv_simd_neon(base, values, start_from_zero) };
         }
@@ -857,7 +875,7 @@ pub fn npv_with_deriv_simd(rate: f64, values: &[f64]) -> (f64, f64) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        if values.len() >= AVX2_MIN_LEN {
+        if values.len() >= SIMD256_MIN_LEN {
             match simd_tier() {
                 SimdTier::Avx2 => {
                     let (simd_sum, simd_deriv) =
@@ -876,6 +894,9 @@ pub fn npv_with_deriv_simd(rate: f64, values: &[f64]) -> (f64, f64) {
 
     #[cfg(target_arch = "aarch64")]
     {
+        // NEON still runs the original per-chunk kernel, so it keeps the original
+        // threshold. `SIMD256_MIN_LEN` was measured for the rewritten x86 kernels on
+        // x86 hardware and does not transfer; re-measure on ARM before reusing it.
         if neon_enabled() && values.len() > 8 {
             let (simd_sum, simd_deriv) = unsafe { npv_with_deriv_neon(rate, &values[1..], 1) };
             return (sum + simd_sum, deriv + simd_deriv);
@@ -1290,6 +1311,65 @@ mod tests {
                 for &start_index in &[0usize, 1, 5] {
                     let (got_sum, got_deriv) =
                         unsafe { npv_with_deriv_avx2(rate, &values, start_index) };
+                    let (want_sum, want_deriv) =
+                        unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, &values, start_index) };
+
+                    let sum_tol = 1e-9 * want_sum.abs().max(1.0);
+                    let deriv_tol = 1e-9 * want_deriv.abs().max(1.0);
+                    assert!(
+                        (got_sum - want_sum).abs() <= sum_tol,
+                        "deriv-sum mismatch: rate {rate}, len {len}, start_index {start_index}: got {got_sum}, want {want_sum}"
+                    );
+                    assert!(
+                        (got_deriv - want_deriv).abs() <= deriv_tol,
+                        "deriv mismatch: rate {rate}, len {len}, start_index {start_index}: got {got_deriv}, want {want_deriv}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The rewritten plain-AVX kernels must agree with the scalar reference at every length:
+    /// below the block size, exactly on a block boundary, and at each of the seven
+    /// possible remainders past one.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_avx_kernels_match_reference() {
+        if !AvxOps::is_supported() {
+            eprintln!("AVX not supported on this CPU, skipping");
+            return;
+        }
+
+        for &rate in &[0.05, 0.12, -0.35, 0.9, 2.5, 1e-6, -0.999] {
+            let base = 1.0 + rate;
+
+            for len in 0..40usize {
+                // varied signs and magnitudes, deterministic
+                let values: Vec<f64> = (0..len)
+                    .map(|i| {
+                        let x = (i as f64 + 1.0) * 137.0357;
+                        if i % 3 == 0 {
+                            -x * 1000.0
+                        } else {
+                            x
+                        }
+                    })
+                    .collect();
+
+                for &start_from_zero in &[true, false] {
+                    let got = unsafe { npv_simd_avx(base, &values, start_from_zero) };
+                    let want =
+                        unsafe { npv_simd_generic::<AutoVecOps>(base, &values, start_from_zero) };
+                    let tol = 1e-9 * want.abs().max(1.0);
+                    assert!(
+                        (got - want).abs() <= tol,
+                        "npv mismatch: rate {rate}, len {len}, start_from_zero {start_from_zero}: got {got}, want {want}"
+                    );
+                }
+
+                for &start_index in &[0usize, 1, 5] {
+                    let (got_sum, got_deriv) =
+                        unsafe { npv_with_deriv_avx(rate, &values, start_index) };
                     let (want_sum, want_deriv) =
                         unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, &values, start_index) };
 

--- a/src/core/periodic/npv.rs
+++ b/src/core/periodic/npv.rs
@@ -575,10 +575,87 @@ unsafe fn npv_simd_avx(base: f64, values: &[f64], start_from_zero: bool) -> f64 
     npv_simd_generic::<AvxOps>(base, values, start_from_zero)
 }
 
+/// Lanes consumed per iteration of the AVX2 kernels: two 4-wide vectors, so the discount
+/// factor and accumulator chains are independent and the loop is not latency-bound.
+#[cfg(target_arch = "x86_64")]
+const AVX2_BLOCK: usize = 8;
+
+/// Shortest slice worth entering the AVX2 kernel for, rather than the auto-vectorized
+/// fallback. Measured, not assumed — see `benches/npv_kernel.rs`.
+#[cfg(target_arch = "x86_64")]
+const AVX2_MIN_LEN: usize = 6;
+
+/// Horizontal sum of a 4-wide vector. Done once at the end of a kernel, never per chunk.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx")]
+unsafe fn hsum_pd(v: std::arch::x86_64::__m256d) -> f64 {
+    use std::arch::x86_64::*;
+    let lo = _mm256_castpd256_pd128(v);
+    let hi = _mm256_extractf128_pd(v, 1);
+    let s = _mm_add_pd(lo, hi);
+    _mm_cvtsd_f64(_mm_add_sd(s, _mm_unpackhi_pd(s, s)))
+}
+
+/// NPV over the whole slice in one pass.
+///
+/// Replaces the per-chunk `SimdOps` path, which recomputed `[1, b, b², b³]` and `b⁴` for
+/// every four elements, divided by the discount factor, and round-tripped the result
+/// through the stack to sum it. Here the powers of `1/base` are carried in registers, the
+/// division becomes a multiply, and there is exactly one horizontal reduction at the end.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2,fma")]
 unsafe fn npv_simd_avx2(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
-    npv_simd_generic::<Avx2Ops>(base, values, start_from_zero)
+    use std::arch::x86_64::*;
+
+    let inv_base = 1.0 / base;
+    let ib2 = inv_base * inv_base;
+    let ib3 = ib2 * inv_base;
+    let ib4 = ib2 * ib2;
+
+    // discount factor of the first element: base^0 or base^-1
+    let p0 = if start_from_zero {
+        1.0
+    } else {
+        inv_base
+    };
+
+    let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
+    let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+    let step = _mm256_set1_pd(ib4 * ib4);
+
+    let mut acc_lo = _mm256_setzero_pd();
+    let mut acc_hi = _mm256_setzero_pd();
+
+    let ptr = values.as_ptr();
+    let blocks = values.len() / AVX2_BLOCK;
+
+    for k in 0..blocks {
+        let i = k * AVX2_BLOCK;
+        acc_lo = _mm256_fmadd_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
+        acc_hi = _mm256_fmadd_pd(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi, acc_hi);
+        pow_lo = _mm256_mul_pd(pow_lo, step);
+        pow_hi = _mm256_mul_pd(pow_hi, step);
+    }
+
+    // A remainder of 4 or more is still worth a vector step; only the last 0-3 go scalar.
+    let mut i = blocks * AVX2_BLOCK;
+    if values.len() - i >= 4 {
+        acc_lo = _mm256_fmadd_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
+        pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+        i += 4;
+    }
+
+    let mut sum = hsum_pd(_mm256_add_pd(acc_lo, acc_hi));
+
+    // lane 0 of pow_lo is the discount factor of the next unprocessed element
+    let mut power = _mm256_cvtsd_f64(pow_lo);
+    while i < values.len() {
+        sum += *ptr.add(i) * power;
+        power *= inv_base;
+        i += 1;
+    }
+
+    sum
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -596,10 +673,86 @@ unsafe fn npv_with_deriv_avx(rate: f64, values: &[f64], start_index: usize) -> (
     npv_with_deriv_generic::<AvxOps>(rate, values, start_index)
 }
 
+/// NPV and its derivative over the whole slice in one pass.
+///
+/// Same treatment as [`npv_simd_avx2`], plus: the index vector is carried and incremented
+/// rather than rebuilt from four `usize -> f64` conversions per chunk, and the `-1/base`
+/// factor common to every derivative term is applied once at the end instead of per element.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2,fma")]
 unsafe fn npv_with_deriv_avx2(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
-    npv_with_deriv_generic::<Avx2Ops>(rate, values, start_index)
+    use std::arch::x86_64::*;
+
+    let base = 1.0 + rate;
+    let inv_base = 1.0 / base;
+    let ib2 = inv_base * inv_base;
+    let ib3 = ib2 * inv_base;
+    let ib4 = ib2 * ib2;
+
+    // Matches `npv_with_deriv_generic`: the discount exponent starts at 1 whatever
+    // `start_index` is — the caller has already handled element 0 — while `start_index`
+    // only feeds the derivative's index weights. The two coincide for the production
+    // call, which passes `&values[1..]` with `start_index == 1`.
+    let p0 = inv_base;
+
+    let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
+    let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+    let step = _mm256_set1_pd(ib4 * ib4);
+
+    let si = start_index as f64;
+    let mut idx_lo = _mm256_set_pd(si + 3.0, si + 2.0, si + 1.0, si);
+    let mut idx_hi = _mm256_add_pd(idx_lo, _mm256_set1_pd(4.0));
+    let idx_step = _mm256_set1_pd(AVX2_BLOCK as f64);
+
+    let mut sum_lo = _mm256_setzero_pd();
+    let mut sum_hi = _mm256_setzero_pd();
+    // accumulates sum(i * v_i / base^i); scaled by -1/base once the loop is done
+    let mut deriv_lo = _mm256_setzero_pd();
+    let mut deriv_hi = _mm256_setzero_pd();
+
+    let ptr = values.as_ptr();
+    let blocks = values.len() / AVX2_BLOCK;
+
+    for k in 0..blocks {
+        let i = k * AVX2_BLOCK;
+
+        let term_lo = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
+        let term_hi = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi);
+
+        sum_lo = _mm256_add_pd(sum_lo, term_lo);
+        sum_hi = _mm256_add_pd(sum_hi, term_hi);
+
+        deriv_lo = _mm256_fmadd_pd(term_lo, idx_lo, deriv_lo);
+        deriv_hi = _mm256_fmadd_pd(term_hi, idx_hi, deriv_hi);
+
+        pow_lo = _mm256_mul_pd(pow_lo, step);
+        pow_hi = _mm256_mul_pd(pow_hi, step);
+        idx_lo = _mm256_add_pd(idx_lo, idx_step);
+        idx_hi = _mm256_add_pd(idx_hi, idx_step);
+    }
+
+    let mut i = blocks * AVX2_BLOCK;
+    if values.len() - i >= 4 {
+        let term = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
+        sum_lo = _mm256_add_pd(sum_lo, term);
+        deriv_lo = _mm256_fmadd_pd(term, idx_lo, deriv_lo);
+        pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+        i += 4;
+    }
+
+    let mut sum = hsum_pd(_mm256_add_pd(sum_lo, sum_hi));
+    let mut weighted = hsum_pd(_mm256_add_pd(deriv_lo, deriv_hi));
+
+    let mut power = _mm256_cvtsd_f64(pow_lo);
+    while i < values.len() {
+        let term = *ptr.add(i) * power;
+        sum += term;
+        weighted += (start_index + i) as f64 * term;
+        power *= inv_base;
+        i += 1;
+    }
+
+    (sum, -weighted * inv_base)
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -663,7 +816,7 @@ pub fn npv_simd(rate: f64, values: &[f64], start_from_zero: Option<bool>) -> f64
 
     #[cfg(target_arch = "x86_64")]
     {
-        if values.len() > 8 {
+        if values.len() >= AVX2_MIN_LEN {
             match simd_tier() {
                 SimdTier::Avx2 => return unsafe { npv_simd_avx2(base, values, start_from_zero) },
                 SimdTier::Avx => return unsafe { npv_simd_avx(base, values, start_from_zero) },
@@ -704,7 +857,7 @@ pub fn npv_with_deriv_simd(rate: f64, values: &[f64]) -> (f64, f64) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        if values.len() > 8 {
+        if values.len() >= AVX2_MIN_LEN {
             match simd_tier() {
                 SimdTier::Avx2 => {
                     let (simd_sum, simd_deriv) =
@@ -1094,5 +1247,106 @@ mod tests {
         let (sum, deriv) = npv_with_deriv_simd(0.0, &empty);
         assert_eq!(sum, 0.0, "NPV of empty array should be 0.0 when rate = 0.0");
         assert_eq!(deriv, 0.0, "Derivative of empty array should be 0.0 when rate = 0.0");
+    }
+
+    /// The rewritten AVX2 kernels must agree with the scalar reference at every length:
+    /// below the block size, exactly on a block boundary, and at each of the seven
+    /// possible remainders past one.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_avx2_kernels_match_reference() {
+        if !Avx2Ops::is_supported() {
+            eprintln!("AVX2 not supported on this CPU, skipping");
+            return;
+        }
+
+        for &rate in &[0.05, 0.12, -0.35, 0.9, 2.5, 1e-6, -0.999] {
+            let base = 1.0 + rate;
+
+            for len in 0..40usize {
+                // varied signs and magnitudes, deterministic
+                let values: Vec<f64> = (0..len)
+                    .map(|i| {
+                        let x = (i as f64 + 1.0) * 137.0357;
+                        if i % 3 == 0 {
+                            -x * 1000.0
+                        } else {
+                            x
+                        }
+                    })
+                    .collect();
+
+                for &start_from_zero in &[true, false] {
+                    let got = unsafe { npv_simd_avx2(base, &values, start_from_zero) };
+                    let want =
+                        unsafe { npv_simd_generic::<AutoVecOps>(base, &values, start_from_zero) };
+                    let tol = 1e-9 * want.abs().max(1.0);
+                    assert!(
+                        (got - want).abs() <= tol,
+                        "npv mismatch: rate {rate}, len {len}, start_from_zero {start_from_zero}: got {got}, want {want}"
+                    );
+                }
+
+                for &start_index in &[0usize, 1, 5] {
+                    let (got_sum, got_deriv) =
+                        unsafe { npv_with_deriv_avx2(rate, &values, start_index) };
+                    let (want_sum, want_deriv) =
+                        unsafe { npv_with_deriv_generic::<AutoVecOps>(rate, &values, start_index) };
+
+                    let sum_tol = 1e-9 * want_sum.abs().max(1.0);
+                    let deriv_tol = 1e-9 * want_deriv.abs().max(1.0);
+                    assert!(
+                        (got_sum - want_sum).abs() <= sum_tol,
+                        "deriv-sum mismatch: rate {rate}, len {len}, start_index {start_index}: got {got_sum}, want {want_sum}"
+                    );
+                    assert!(
+                        (got_deriv - want_deriv).abs() <= deriv_tol,
+                        "deriv mismatch: rate {rate}, len {len}, start_index {start_index}: got {got_deriv}, want {want_deriv}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Long series: the reciprocal-power chain accumulates error over the whole slice, so
+    /// check it stays negligible rather than assuming it does.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_avx2_kernels_long_series_accuracy() {
+        if !Avx2Ops::is_supported() {
+            return;
+        }
+
+        let values: Vec<f64> = (0..5000)
+            .map(|i| {
+                if i == 0 {
+                    -1.0e8
+                } else {
+                    25_000.0 + (i % 7) as f64 * 13.0
+                }
+            })
+            .collect();
+
+        for &rate in &[0.004, 0.05, 0.35] {
+            let base = 1.0 + rate;
+
+            let got = unsafe { npv_simd_avx2(base, &values, true) };
+            let want = get_reference_npv(&values, rate);
+            assert!(
+                (got - want).abs() <= 1e-9 * want.abs().max(1.0),
+                "long npv drift: rate {rate}: got {got}, want {want}"
+            );
+
+            let (got_sum, got_deriv) = unsafe { npv_with_deriv_avx2(rate, &values[1..], 1) };
+            let (want_sum, want_deriv) = get_reference_npv_deriv(&values[1..], rate, 1);
+            assert!(
+                (got_sum - want_sum).abs() <= 1e-9 * want_sum.abs().max(1.0),
+                "long deriv-sum drift: rate {rate}: got {got_sum}, want {want_sum}"
+            );
+            assert!(
+                (got_deriv - want_deriv).abs() <= 1e-9 * want_deriv.abs().max(1.0),
+                "long deriv drift: rate {rate}: got {got_deriv}, want {want_deriv}"
+            );
+        }
     }
 }

--- a/src/core/periodic/npv.rs
+++ b/src/core/periodic/npv.rs
@@ -1,8 +1,15 @@
 /// CPU support for the AVX2+FMA tier. Kept as a free function rather than a method on a
 /// per-tier type: dispatch and the kernel tests are the only callers.
+///
+/// `avx` is checked alongside `avx2` and `fma` because the AVX2 kernels call `hsum_pd`,
+/// which is an AVX-level `#[target_feature]` function — that is a real precondition of
+/// entering this tier, so it is tested rather than assumed. No CPU exposes AVX2 without
+/// AVX, but the check costs nothing: `simd_tier` resolves this once and caches it.
 #[cfg(target_arch = "x86_64")]
 fn avx2_supported() -> bool {
-    is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")
+    is_x86_feature_detected!("avx")
+        && is_x86_feature_detected!("avx2")
+        && is_x86_feature_detected!("fma")
 }
 
 /// CPU support for the plain-AVX tier.
@@ -106,6 +113,13 @@ const SIMD256_BLOCK: usize = 8;
 /// fallback. Measured, not assumed — see `benches/npv_kernel.rs`.
 #[cfg(target_arch = "x86_64")]
 const SIMD256_MIN_LEN: usize = 6;
+
+/// The same threshold for the NPV+derivative kernels, which is higher: those set up eight
+/// vectors (two discount-factor chains, two index chains, two sum and two weight
+/// accumulators) before the first multiply. Mirrors `NEON_DERIV_MIN_LEN`. The kernel is
+/// handed `&values[1..]`, so a slice of this length gives it exactly one block.
+#[cfg(target_arch = "x86_64")]
+const SIMD256_DERIV_MIN_LEN: usize = SIMD256_BLOCK + 1;
 
 /// Horizontal sum of a 4-wide vector. Done once at the end of a kernel, never per chunk.
 #[cfg(target_arch = "x86_64")]
@@ -603,7 +617,7 @@ pub fn npv_with_deriv_simd(rate: f64, values: &[f64]) -> (f64, f64) {
 
     #[cfg(target_arch = "x86_64")]
     {
-        if values.len() >= SIMD256_MIN_LEN {
+        if values.len() >= SIMD256_DERIV_MIN_LEN {
             match simd_tier() {
                 SimdTier::Avx2 => {
                     let (simd_sum, simd_deriv) =
@@ -1067,6 +1081,48 @@ mod tests {
             );
 
             let (got_sum, got_deriv) = unsafe { npv_with_deriv_avx2(rate, &values[1..], 1) };
+            let (want_sum, want_deriv) = get_reference_npv_deriv(&values[1..], rate, 1);
+            assert!(
+                (got_sum - want_sum).abs() <= 1e-9 * want_sum.abs().max(1.0),
+                "long deriv-sum drift: rate {rate}: got {got_sum}, want {want_sum}"
+            );
+            assert!(
+                (got_deriv - want_deriv).abs() <= 1e-9 * want_deriv.abs().max(1.0),
+                "long deriv drift: rate {rate}: got {got_deriv}, want {want_deriv}"
+            );
+        }
+    }
+    /// Same for the plain-AVX tier. Worth its own case rather than trusting the AVX2 one:
+    /// without FMA each accumulate rounds twice, so the drift over 5000 elements is a
+    /// genuinely different quantity.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_avx_kernels_long_series_accuracy() {
+        if !avx_supported() {
+            return;
+        }
+
+        let values: Vec<f64> = (0..5000)
+            .map(|i| {
+                if i == 0 {
+                    -1.0e8
+                } else {
+                    25_000.0 + (i % 7) as f64 * 13.0
+                }
+            })
+            .collect();
+
+        for &rate in &[0.004, 0.05, 0.35] {
+            let base = 1.0 + rate;
+
+            let got = unsafe { npv_simd_avx(base, &values, true) };
+            let want = get_reference_npv(&values, rate);
+            assert!(
+                (got - want).abs() <= 1e-9 * want.abs().max(1.0),
+                "long npv drift: rate {rate}: got {got}, want {want}"
+            );
+
+            let (got_sum, got_deriv) = unsafe { npv_with_deriv_avx(rate, &values[1..], 1) };
             let (want_sum, want_deriv) = get_reference_npv_deriv(&values[1..], rate, 1);
             assert!(
                 (got_sum - want_sum).abs() <= 1e-9 * want_sum.abs().max(1.0),

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -39,11 +39,34 @@ pub(crate) fn initial_guess(values: &[f64]) -> f64 {
     guess.clamp(-0.9, 0.1)
 }
 
-pub(crate) fn is_a_good_rate<F>(rate: f64, f: F) -> bool
+pub(crate) fn is_a_good_rate_within<F>(rate: f64, tolerance: f64, f: F) -> bool
 where
     F: Fn(f64) -> f64,
 {
-    rate.is_finite() && f(rate).abs() < 1e-3
+    rate.is_finite() && f(rate).abs() <= tolerance
+}
+
+/// Magnitude of a cash flow, used to judge how close to zero an NPV really is.
+///
+/// The npv terms sum to something of this order, so f64 cancellation puts a floor of
+/// roughly `n * eps * scale` on `|npv|` at the true root. A fixed `|npv| < 1e-3` is
+/// therefore both far too lax for flows in the hundreds and unreachable for flows in
+/// the billions — a 1e8 cash flow cannot get `|npv|` below ~1e-8 * 1e8 = 1 no matter
+/// how exact the rate is.
+pub(crate) fn npv_scale(values: &[f64]) -> f64 {
+    values.iter().map(|v| v.abs()).sum::<f64>().max(1.0)
+}
+
+/// Tolerance for accepting a rate a solver converged to. Sits ~5 orders of magnitude
+/// above the cancellation floor, so a genuine root always passes.
+pub(crate) fn converged_rate_tolerance(scale: f64) -> f64 {
+    1e-9 * scale
+}
+
+/// Tolerance for accepting a rate a solver only got *near*. Keeps the historical 1e-3
+/// floor for small cash flows and widens to the relative one for large ones.
+pub(crate) fn approximate_rate_tolerance(scale: f64) -> f64 {
+    converged_rate_tolerance(scale).max(1e-3)
 }
 
 #[cfg(test)]

--- a/tests/test_periodic.rs
+++ b/tests/test_periodic.rs
@@ -61,7 +61,7 @@ fn test_fv_vectorized_multi() {
     let pv = [-100.0, -150.0, -200.0];
     let pmt_at_beginning = [false, false, true];
 
-    let mut result = vec![0.0; 3];
+    let mut result = [0.0; 3];
 
     for i in 0..3 {
         result[i] = fv(rates[i], nper[i], -100.0, pv[i], pmt_at_beginning[i]);
@@ -74,8 +74,8 @@ fn test_fv_vectorized_multi() {
 
 #[rstest]
 fn test_fv_vectorized_iterable() {
-    let pmt_values = vec![-100.0, -200.0, -300.0];
-    let mut actual = vec![0.0; 3];
+    let pmt_values = [-100.0, -200.0, -300.0];
+    let mut actual = [0.0; 3];
 
     for (i, &pmt) in pmt_values.iter().enumerate() {
         actual[i] = fv(0.05 / 12.0, 10.0 * 12.0, pmt, -100.0, false);

--- a/tests/test_periodic.rs
+++ b/tests/test_periodic.rs
@@ -650,3 +650,99 @@ fn test_cumipmt_works() {
     let result = cumipmt(0.09 / 12.0, 30.0 * 12.0, 125_000.0, 1.0, 1.0, false);
     assert_almost_eq!(result, -937.5, 1e-7);
 }
+
+// ------------ IRR with a guess ----------------
+
+/// A guess must not change *which* root is reported when it points at the root the
+/// guess-free call finds. This is the path an IRR series takes: each period seeds the
+/// next, so a drifting answer would compound across the series.
+#[rstest]
+#[case(&[-100.0, 39.0, 59.0, 55.0, 20.0])]
+#[case(&[-100.0, 100.0, 0.0, -7.0])]
+#[case(&[-40000.0, 5000.0, 8000.0, 12000.0, 30000.0])]
+#[case(&[-10.0, 2.0, 2.0, 2.0, 2.0])]
+// large magnitudes: |npv| < 1e-3 is unreachable here regardless of how exact the rate is
+#[case(&[
+    -1.44852555e+08,  1.28859998e+06,  1.27305118e+06,  1.25407349e+06,
+    1.24199669e+06,  1.22647792e+06,  1.21095552e+06,  1.19206955e+06,
+    1.17989821e+06,  1.16436524e+06,  1.14883185e+06,  1.12945217e+06,
+    1.11780102e+06,  1.10228427e+06,  1.08671783e+06,  1.06755759e+06,
+    1.05502327e+06,  1.03885451e+06,  1.02247003e+06,  1.00227444e+06,
+    9.88024873e+05
+])]
+#[case(&[
+    -5099701.25, -22503.796875, -22503.79296875, -22503.79296875, -20907.26171875,
+    -17899.7421875, -17899.7421875, -17899.7421875, -14660.69140625, -12447.80078125,
+    -12447.796875, -12018.1640625, -5991.81640625, -5991.81640625, -5991.81640625,
+    -2885.875, 1653.125, 1653.125, 1653.125, 8307.328125, 11110408.45703125
+])]
+fn test_irr_guess_agrees_with_no_guess(#[case] input: &[f64]) {
+    let expected = irr(input, None).unwrap();
+
+    // exact seed, and seeds off by a plausible period-over-period drift
+    for offset in [0.0, 1e-9, 0.005, -0.005, 0.05, -0.05] {
+        let rate = irr(input, Some(expected + offset)).unwrap();
+        assert_almost_eq!(rate, expected, 1e-7);
+    }
+}
+
+/// A guess nowhere near any root must still produce a genuine root, not NaN and not a
+/// rate that merely satisfies a loose absolute tolerance.
+#[rstest]
+#[case(&[-100.0, 39.0, 59.0, 55.0, 20.0])]
+#[case(&[-40000.0, 5000.0, 8000.0, 12000.0, 30000.0])]
+#[case(&[-10.0, 2.0, 2.0, 2.0, 2.0])]
+#[case(&[
+    -1.44852555e+08,  1.28859998e+06,  1.27305118e+06,  1.25407349e+06,
+    1.24199669e+06,  1.22647792e+06,  1.21095552e+06,  1.19206955e+06,
+    1.17989821e+06,  1.16436524e+06,  1.14883185e+06,  1.12945217e+06,
+    1.11780102e+06,  1.10228427e+06,  1.08671783e+06,  1.06755759e+06,
+    1.05502327e+06,  1.03885451e+06,  1.02247003e+06,  1.00227444e+06,
+    9.88024873e+05
+])]
+fn test_irr_absurd_guess_still_finds_a_root(#[case] input: &[f64]) {
+    let scale: f64 = input.iter().map(|v| v.abs()).sum();
+
+    for guess in [-0.999, -0.9, 0.0, 5.0, 100.0] {
+        let rate = irr(input, Some(guess)).unwrap();
+        assert!(rate.is_finite(), "guess {guess} produced {rate}");
+        // npv must vanish relative to the size of the cash flow
+        assert!(
+            npv(rate, input, Some(true)).abs() <= 1e-6 * scale,
+            "guess {guess} produced rate {rate}, npv {}",
+            npv(rate, input, Some(true))
+        );
+    }
+}
+
+/// Upstream https://github.com/Anexen/pyxirr/issues/69: an all-zero cash flow used to
+/// panic. Our `non_zero_range` guard fixes it differently than upstream's `unwrap_or(0)`,
+/// so pin the behavior here too.
+#[rstest]
+#[case(&[0.0, 0.0, 0.0, 0.0])]
+#[case(&[-0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])]
+#[case(&[0.0])]
+#[case(&[])]
+fn test_irr_all_zeros(#[case] input: &[f64]) {
+    assert!(irr(input, None).is_err(), "all-zero cash flow must be rejected, not panic");
+    assert!(irr(input, Some(0.1)).is_err(), "same with a guess");
+}
+
+/// Roots below -99.9% fall outside the `[-0.999, 100]` bracket, so they can only be found
+/// by the last-resort grid search. With the previous breakpoints (which started at -0.9)
+/// these returned NaN. See `benches/grid_fallback.rs` for the cost of the wider grid.
+#[rstest]
+#[case(&[-4002.0, 0.001, -0.001, 1e-6], -0.9995)]
+#[case(&[
+    -4002.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1e-60,
+], -0.9995507255384063)]
+fn test_irr_root_below_minus_999(#[case] input: &[f64], #[case] expected: f64) {
+    let rate = irr(input, None).unwrap();
+    assert!(rate.is_finite(), "expected a root near {expected}, got {rate}");
+    assert_almost_eq!(rate, expected, 1e-9);
+
+    // and it really is a root, relative to the size of the cash flow
+    let scale: f64 = input.iter().map(|v| v.abs()).sum();
+    assert!(npv(rate, input, Some(true)).abs() <= 1e-6 * scale);
+}

--- a/tests/test_scheduled.rs
+++ b/tests/test_scheduled.rs
@@ -192,8 +192,8 @@ fn test_sum_xfv_eq_xnfv() {
     let xnfv_result = xnfv(rate, &dates, &amounts, None).unwrap();
 
     // Find min and max dates
-    let min_date = (*dates.iter().min().unwrap()).into();
-    let max_date = (*dates.iter().max().unwrap()).into();
+    let min_date = *dates.iter().min().unwrap();
+    let max_date = *dates.iter().max().unwrap();
 
     // Calculate sum of individual xfv values
     let sum_xfv_result: f64 = dates


### PR DESCRIPTION
Two independent changes that compound: the NPV kernels every solver iteration runs
through, and the IRR solver that calls them. 5 commits, 11 files, +1190/-780 against
`main`.

## Results

Single-call IRR (x86-64, AVX2), against `main`:

| bench | before | after | change |
| --- | --- | --- | --- |
| `irr_50` | 452 ns | 276 ns | -38.9% |
| `irr_100` | 711 ns | 347 ns | -51.2% |
| `irr_500` | 3.11 µs | 1.76 µs | -43.2% |
| `irr_1000` | 6.23 µs | 2.76 µs | -55.7% |
| `irr_orbit_001` | 997 ns | 376 ns | -62.0% |

IRR series — `irr` once per prefix of a cash flow, which is the workload that
motivated this (new `benches/prefix_irr.rs`):

| bench | before | after | change |
| --- | --- | --- | --- |
| `cold/rw_100` | 117 µs | 58.7 µs | -49.9% |
| `warm/rw_100` | 25.0 µs | 10.7 µs | -57.3% |
| `cold/orbit_001` | 69.0 µs | 34.7 µs | -50.1% |
| `warm/orbit_001` | 52.1 µs | 12.5 µs | -75.9% |

Cold to warm on the new code is a further 5.5x (`rw_100`: 58.7 -> 10.7 µs), so
callers computing an IRR series should pass the previous period's rate as `guess`.

Kernels in isolation (new `benches/npv_kernel.rs`), each against the per-chunk path
it replaces:

| tier | speedup | example |
| --- | --- | --- |
| AVX2 | 2.0-5.3x | n=1024: 429 -> 90 ns |
| AVX | 1.7-4.5x | n=100: 46.2 -> 10.3 ns |
| NEON (Apple M2) | 1.8-4.3x | n=1024: 676 -> 156 ns |

## What changed

**The kernels.** The old per-chunk `SimdOps` path recomputed `[1, b, b², b³]` and `b⁴`
for every four elements, divided by the discount factor, and round-tripped each chunk
through the stack to sum it. The rewrite makes one pass: powers of `1/base` carried in
registers so the division becomes a multiply, independent accumulator chains so the
loop is throughput-bound rather than stalled on FMA latency, the derivative's index
vector incremented rather than rebuilt from `usize -> f64` conversions, `-1/base`
applied once at the end, and a single horizontal reduction. The per-chunk prefetch and
aligned/unaligned branch are gone; neither paid for itself.

AVX and AVX2 are generated from one macro, since they differ only in how a
multiply-accumulate is spelled. NEON is a separate 128-bit implementation.

**The solver.** `irr` ran brentq over `[0, 100]` unconditionally before consulting
`guess`, so the guess only took effect when brentq failed outright — `irr_complex` and
`irr_with_guess` benchmarked identically. A capped Newton warm start now runs first
when a guess is supplied. Its convergence test is step-relative rather than
`|npv| < 1e-7`, which is unreachable in f64 for cash flows in the billions no matter how
exact the rate is; the same scale-relative reasoning now applies to accepting a rate in
the fallback, with the historical 1e-3 floor kept for small cash flows.
