### PR TITLE
chore: migrate to the 2024 edition

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 reorder_imports = true
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pyxirr"
 version = "0.10.6"
 authors = ["Anexen"]
-edition = "2021"
+edition = "2024"
 description = "Rust-powered collection of financial functions for Python."
 readme = "README.md"
 homepage = "https://github.com/Anexen/pyxirr"

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use pyxirr::{irr, npv, xirr, xnpv};
 
 #[path = "../tests/common/mod.rs"]

--- a/benches/grid_fallback.rs
+++ b/benches/grid_fallback.rs
@@ -4,7 +4,7 @@
 //! bracket searches find no sign change and Newton does not converge — so the grid search
 //! runs to exhaustion. Both have a real IRR just below -99.9%, outside the `[-0.999, 100]`
 //! bracket, which is precisely the region the current breakpoints cannot reach.
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use pyxirr::irr;
 
 /// n=4, root at -0.99950. The tail term is negligible at rate -0.999 but dominates as the

--- a/benches/input.rs
+++ b/benches/input.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use pyxirr::xirr;
 use time::macros::date;
 

--- a/benches/npf.rs
+++ b/benches/npf.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use pyxirr::{irr, mirr};
 
 #[path = "../tests/common/mod.rs"]

--- a/benches/npv_kernel.rs
+++ b/benches/npv_kernel.rs
@@ -4,7 +4,7 @@
 //! Also where the `*_MIN_LEN` thresholds are measured: run this with `ENABLE_NEON=0` (or
 //! `ENABLE_AVX2=0 ENABLE_AVX=0`) to time the auto-vectorized fallback at each length, then
 //! with the kernels on, and take the crossover.
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use pyxirr::{irr, npv};
 
 fn cash_flow(len: usize) -> Vec<f64> {

--- a/benches/prefix_irr.rs
+++ b/benches/prefix_irr.rs
@@ -1,7 +1,7 @@
 //! Mirrors the consumer workload that motivated this work: an IRR series, where
 //! `irr` is called once per prefix of a cash flow. Consecutive prefixes have very
 //! similar rates, so the previous result is a near-perfect guess for the next one.
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use pyxirr::irr;
 
 #[path = "../tests/common/mod.rs"]

--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt, str::FromStr};
 
-use time::{macros::format_description, Date};
+use time::{Date, macros::format_description};
 
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Copy)]
 pub struct DateLike(Date);

--- a/src/core/periodic.rs
+++ b/src/core/periodic.rs
@@ -2,7 +2,7 @@ mod irr;
 mod npv;
 
 use super::{
-    models::{validate, InvalidPaymentsError},
+    models::{InvalidPaymentsError, validate},
     optimize::{
         brentq, brentq_grid_search, newton_raphson_2, newton_raphson_warm,
         newton_raphson_with_default_deriv,
@@ -566,13 +566,13 @@ pub fn mirr(
 
     let positive: f64 = powers(1. + reinvest_rate, values.len(), true)
         .zip(values.iter().rev())
-        .filter(|(_r, &v)| v > 0.0)
+        .filter(|&(_, v)| *v > 0.0)
         .map(|(r, v)| v * r)
         .sum();
 
     let negative: f64 = powers(1. + finance_rate, values.len(), true)
         .zip(values.iter())
-        .filter(|(_r, &v)| v < 0.0)
+        .filter(|&(_, v)| *v < 0.0)
         .map(|(r, &v)| v / r)
         .sum();
 

--- a/src/core/periodic/npv.rs
+++ b/src/core/periodic/npv.rs
@@ -165,57 +165,63 @@ macro_rules! define_simd256_kernels {
         /// division becomes a multiply, and there is exactly one horizontal reduction at the end.
         #[target_feature(enable = $feature)]
         unsafe fn $npv(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
-            use std::arch::x86_64::*;
+            // SAFETY: reached only via `simd_tier`, which checked this CPU supports
+            // `$feature`. Every load is in bounds: the block loop stops at
+            // `blocks * SIMD256_BLOCK <= values.len()`, the 4-wide remainder step is guarded
+            // by `values.len() - i >= 4`, and the scalar tail by `i < values.len()`.
+            unsafe {
+                use std::arch::x86_64::*;
 
-            let inv_base = 1.0 / base;
-            let ib2 = inv_base * inv_base;
-            let ib3 = ib2 * inv_base;
-            let ib4 = ib2 * ib2;
+                let inv_base = 1.0 / base;
+                let ib2 = inv_base * inv_base;
+                let ib3 = ib2 * inv_base;
+                let ib4 = ib2 * ib2;
 
-            // discount factor of the first element: base^0 or base^-1
-            let p0 = if start_from_zero {
-                1.0
-            } else {
-                inv_base
-            };
+                // discount factor of the first element: base^0 or base^-1
+                let p0 = if start_from_zero {
+                    1.0
+                } else {
+                    inv_base
+                };
 
-            let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
-            let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
-            let step = _mm256_set1_pd(ib4 * ib4);
+                let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
+                let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+                let step = _mm256_set1_pd(ib4 * ib4);
 
-            let mut acc_lo = _mm256_setzero_pd();
-            let mut acc_hi = _mm256_setzero_pd();
+                let mut acc_lo = _mm256_setzero_pd();
+                let mut acc_hi = _mm256_setzero_pd();
 
-            let ptr = values.as_ptr();
-            let blocks = values.len() / SIMD256_BLOCK;
+                let ptr = values.as_ptr();
+                let blocks = values.len() / SIMD256_BLOCK;
 
-            for k in 0..blocks {
-                let i = k * SIMD256_BLOCK;
-                acc_lo = $madd!(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
-                acc_hi = $madd!(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi, acc_hi);
-                pow_lo = _mm256_mul_pd(pow_lo, step);
-                pow_hi = _mm256_mul_pd(pow_hi, step);
+                for k in 0..blocks {
+                    let i = k * SIMD256_BLOCK;
+                    acc_lo = $madd!(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
+                    acc_hi = $madd!(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi, acc_hi);
+                    pow_lo = _mm256_mul_pd(pow_lo, step);
+                    pow_hi = _mm256_mul_pd(pow_hi, step);
+                }
+
+                // A remainder of 4 or more is still worth a vector step; only the last 0-3 go scalar.
+                let mut i = blocks * SIMD256_BLOCK;
+                if values.len() - i >= 4 {
+                    acc_lo = $madd!(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
+                    pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+                    i += 4;
+                }
+
+                let mut sum = hsum_pd(_mm256_add_pd(acc_lo, acc_hi));
+
+                // lane 0 of pow_lo is the discount factor of the next unprocessed element
+                let mut power = _mm256_cvtsd_f64(pow_lo);
+                while i < values.len() {
+                    sum += *ptr.add(i) * power;
+                    power *= inv_base;
+                    i += 1;
+                }
+
+                sum
             }
-
-            // A remainder of 4 or more is still worth a vector step; only the last 0-3 go scalar.
-            let mut i = blocks * SIMD256_BLOCK;
-            if values.len() - i >= 4 {
-                acc_lo = $madd!(_mm256_loadu_pd(ptr.add(i)), pow_lo, acc_lo);
-                pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
-                i += 4;
-            }
-
-            let mut sum = hsum_pd(_mm256_add_pd(acc_lo, acc_hi));
-
-            // lane 0 of pow_lo is the discount factor of the next unprocessed element
-            let mut power = _mm256_cvtsd_f64(pow_lo);
-            while i < values.len() {
-                sum += *ptr.add(i) * power;
-                power *= inv_base;
-                i += 1;
-            }
-
-            sum
         }
 
         /// NPV and its derivative over the whole slice in one pass.
@@ -225,78 +231,84 @@ macro_rules! define_simd256_kernels {
         /// factor common to every derivative term is applied once at the end instead of per element.
         #[target_feature(enable = $feature)]
         unsafe fn $npv_deriv(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
-            use std::arch::x86_64::*;
+            // SAFETY: reached only via `simd_tier`, which checked this CPU supports
+            // `$feature`. Every load is in bounds: the block loop stops at
+            // `blocks * SIMD256_BLOCK <= values.len()`, the 4-wide remainder step is guarded
+            // by `values.len() - i >= 4`, and the scalar tail by `i < values.len()`.
+            unsafe {
+                use std::arch::x86_64::*;
 
-            let base = 1.0 + rate;
-            let inv_base = 1.0 / base;
-            let ib2 = inv_base * inv_base;
-            let ib3 = ib2 * inv_base;
-            let ib4 = ib2 * ib2;
+                let base = 1.0 + rate;
+                let inv_base = 1.0 / base;
+                let ib2 = inv_base * inv_base;
+                let ib3 = ib2 * inv_base;
+                let ib4 = ib2 * ib2;
 
-            // Matches `npv_with_deriv_autovec`: the discount exponent starts at 1 whatever
-            // `start_index` is — the caller has already handled element 0 — while `start_index`
-            // only feeds the derivative's index weights. The two coincide for the production
-            // call, which passes `&values[1..]` with `start_index == 1`.
-            let p0 = inv_base;
+                // Matches `npv_with_deriv_autovec`: the discount exponent starts at 1 whatever
+                // `start_index` is — the caller has already handled element 0 — while `start_index`
+                // only feeds the derivative's index weights. The two coincide for the production
+                // call, which passes `&values[1..]` with `start_index == 1`.
+                let p0 = inv_base;
 
-            let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
-            let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
-            let step = _mm256_set1_pd(ib4 * ib4);
+                let mut pow_lo = _mm256_set_pd(p0 * ib3, p0 * ib2, p0 * inv_base, p0);
+                let mut pow_hi = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+                let step = _mm256_set1_pd(ib4 * ib4);
 
-            let si = start_index as f64;
-            let mut idx_lo = _mm256_set_pd(si + 3.0, si + 2.0, si + 1.0, si);
-            let mut idx_hi = _mm256_add_pd(idx_lo, _mm256_set1_pd(4.0));
-            let idx_step = _mm256_set1_pd(SIMD256_BLOCK as f64);
+                let si = start_index as f64;
+                let mut idx_lo = _mm256_set_pd(si + 3.0, si + 2.0, si + 1.0, si);
+                let mut idx_hi = _mm256_add_pd(idx_lo, _mm256_set1_pd(4.0));
+                let idx_step = _mm256_set1_pd(SIMD256_BLOCK as f64);
 
-            let mut sum_lo = _mm256_setzero_pd();
-            let mut sum_hi = _mm256_setzero_pd();
-            // accumulates sum(i * v_i / base^i); scaled by -1/base once the loop is done
-            let mut deriv_lo = _mm256_setzero_pd();
-            let mut deriv_hi = _mm256_setzero_pd();
+                let mut sum_lo = _mm256_setzero_pd();
+                let mut sum_hi = _mm256_setzero_pd();
+                // accumulates sum(i * v_i / base^i); scaled by -1/base once the loop is done
+                let mut deriv_lo = _mm256_setzero_pd();
+                let mut deriv_hi = _mm256_setzero_pd();
 
-            let ptr = values.as_ptr();
-            let blocks = values.len() / SIMD256_BLOCK;
+                let ptr = values.as_ptr();
+                let blocks = values.len() / SIMD256_BLOCK;
 
-            for k in 0..blocks {
-                let i = k * SIMD256_BLOCK;
+                for k in 0..blocks {
+                    let i = k * SIMD256_BLOCK;
 
-                let term_lo = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
-                let term_hi = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi);
+                    let term_lo = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
+                    let term_hi = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i + 4)), pow_hi);
 
-                sum_lo = _mm256_add_pd(sum_lo, term_lo);
-                sum_hi = _mm256_add_pd(sum_hi, term_hi);
+                    sum_lo = _mm256_add_pd(sum_lo, term_lo);
+                    sum_hi = _mm256_add_pd(sum_hi, term_hi);
 
-                deriv_lo = $madd!(term_lo, idx_lo, deriv_lo);
-                deriv_hi = $madd!(term_hi, idx_hi, deriv_hi);
+                    deriv_lo = $madd!(term_lo, idx_lo, deriv_lo);
+                    deriv_hi = $madd!(term_hi, idx_hi, deriv_hi);
 
-                pow_lo = _mm256_mul_pd(pow_lo, step);
-                pow_hi = _mm256_mul_pd(pow_hi, step);
-                idx_lo = _mm256_add_pd(idx_lo, idx_step);
-                idx_hi = _mm256_add_pd(idx_hi, idx_step);
+                    pow_lo = _mm256_mul_pd(pow_lo, step);
+                    pow_hi = _mm256_mul_pd(pow_hi, step);
+                    idx_lo = _mm256_add_pd(idx_lo, idx_step);
+                    idx_hi = _mm256_add_pd(idx_hi, idx_step);
+                }
+
+                let mut i = blocks * SIMD256_BLOCK;
+                if values.len() - i >= 4 {
+                    let term = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
+                    sum_lo = _mm256_add_pd(sum_lo, term);
+                    deriv_lo = $madd!(term, idx_lo, deriv_lo);
+                    pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
+                    i += 4;
+                }
+
+                let mut sum = hsum_pd(_mm256_add_pd(sum_lo, sum_hi));
+                let mut weighted = hsum_pd(_mm256_add_pd(deriv_lo, deriv_hi));
+
+                let mut power = _mm256_cvtsd_f64(pow_lo);
+                while i < values.len() {
+                    let term = *ptr.add(i) * power;
+                    sum += term;
+                    weighted += (start_index + i) as f64 * term;
+                    power *= inv_base;
+                    i += 1;
+                }
+
+                (sum, -weighted * inv_base)
             }
-
-            let mut i = blocks * SIMD256_BLOCK;
-            if values.len() - i >= 4 {
-                let term = _mm256_mul_pd(_mm256_loadu_pd(ptr.add(i)), pow_lo);
-                sum_lo = _mm256_add_pd(sum_lo, term);
-                deriv_lo = $madd!(term, idx_lo, deriv_lo);
-                pow_lo = _mm256_mul_pd(pow_lo, _mm256_set1_pd(ib4));
-                i += 4;
-            }
-
-            let mut sum = hsum_pd(_mm256_add_pd(sum_lo, sum_hi));
-            let mut weighted = hsum_pd(_mm256_add_pd(deriv_lo, deriv_hi));
-
-            let mut power = _mm256_cvtsd_f64(pow_lo);
-            while i < values.len() {
-                let term = *ptr.add(i) * power;
-                sum += term;
-                weighted += (start_index + i) as f64 * term;
-                power *= inv_base;
-                i += 1;
-            }
-
-            (sum, -weighted * inv_base)
         }
     };
 }
@@ -337,78 +349,84 @@ const NEON_DERIV_MIN_LEN: usize = NEON_BLOCK + 1;
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn npv_simd_neon(base: f64, values: &[f64], start_from_zero: bool) -> f64 {
-    use std::arch::aarch64::*;
+    // SAFETY: NEON is mandatory in the aarch64 base ISA, so the target feature is
+    // always satisfied. Every load is in bounds: the block loop stops at
+    // `blocks * NEON_BLOCK <= len`, each of the three pair steps is guarded by
+    // `len - i >= 2`, and the final single element by `i < len`.
+    unsafe {
+        use std::arch::aarch64::*;
 
-    let inv_base = 1.0 / base;
-    let ib2 = inv_base * inv_base;
-    let ib4 = ib2 * ib2;
-    let ib8 = ib4 * ib4;
+        let inv_base = 1.0 / base;
+        let ib2 = inv_base * inv_base;
+        let ib4 = ib2 * ib2;
+        let ib8 = ib4 * ib4;
 
-    // discount factor of the first element: base^0 or base^-1
-    let p0 = if start_from_zero {
-        1.0
-    } else {
-        inv_base
-    };
+        // discount factor of the first element: base^0 or base^-1
+        let p0 = if start_from_zero {
+            1.0
+        } else {
+            inv_base
+        };
 
-    // pow_j carries the factors of elements i + 2j and i + 2j + 1
-    let mut pow0 = vcombine_f64(vdup_n_f64(p0), vdup_n_f64(p0 * inv_base));
-    let mut pow1 = vmulq_n_f64(pow0, ib2);
-    let mut pow2 = vmulq_n_f64(pow0, ib4);
-    let mut pow3 = vmulq_n_f64(pow1, ib4);
-    let step = vdupq_n_f64(ib8);
+        // pow_j carries the factors of elements i + 2j and i + 2j + 1
+        let mut pow0 = vcombine_f64(vdup_n_f64(p0), vdup_n_f64(p0 * inv_base));
+        let mut pow1 = vmulq_n_f64(pow0, ib2);
+        let mut pow2 = vmulq_n_f64(pow0, ib4);
+        let mut pow3 = vmulq_n_f64(pow1, ib4);
+        let step = vdupq_n_f64(ib8);
 
-    let mut acc0 = vdupq_n_f64(0.0);
-    let mut acc1 = vdupq_n_f64(0.0);
-    let mut acc2 = vdupq_n_f64(0.0);
-    let mut acc3 = vdupq_n_f64(0.0);
+        let mut acc0 = vdupq_n_f64(0.0);
+        let mut acc1 = vdupq_n_f64(0.0);
+        let mut acc2 = vdupq_n_f64(0.0);
+        let mut acc3 = vdupq_n_f64(0.0);
 
-    let ptr = values.as_ptr();
-    let len = values.len();
-    let blocks = len / NEON_BLOCK;
+        let ptr = values.as_ptr();
+        let len = values.len();
+        let blocks = len / NEON_BLOCK;
 
-    for k in 0..blocks {
-        let i = k * NEON_BLOCK;
-        acc0 = vfmaq_f64(acc0, vld1q_f64(ptr.add(i)), pow0);
-        acc1 = vfmaq_f64(acc1, vld1q_f64(ptr.add(i + 2)), pow1);
-        acc2 = vfmaq_f64(acc2, vld1q_f64(ptr.add(i + 4)), pow2);
-        acc3 = vfmaq_f64(acc3, vld1q_f64(ptr.add(i + 6)), pow3);
-        pow0 = vmulq_f64(pow0, step);
-        pow1 = vmulq_f64(pow1, step);
-        pow2 = vmulq_f64(pow2, step);
-        pow3 = vmulq_f64(pow3, step);
+        for k in 0..blocks {
+            let i = k * NEON_BLOCK;
+            acc0 = vfmaq_f64(acc0, vld1q_f64(ptr.add(i)), pow0);
+            acc1 = vfmaq_f64(acc1, vld1q_f64(ptr.add(i + 2)), pow1);
+            acc2 = vfmaq_f64(acc2, vld1q_f64(ptr.add(i + 4)), pow2);
+            acc3 = vfmaq_f64(acc3, vld1q_f64(ptr.add(i + 6)), pow3);
+            pow0 = vmulq_f64(pow0, step);
+            pow1 = vmulq_f64(pow1, step);
+            pow2 = vmulq_f64(pow2, step);
+            pow3 = vmulq_f64(pow3, step);
+        }
+
+        // Up to three whole pairs are left over; each already has its factors in pow_j, so the
+        // remainder costs no extra power arithmetic. `tail_pow` tracks the vector whose lane 0
+        // is the factor of the next unprocessed element.
+        let mut i = blocks * NEON_BLOCK;
+        let mut tail_pow = pow0;
+        if len - i >= 2 {
+            acc0 = vfmaq_f64(acc0, vld1q_f64(ptr.add(i)), pow0);
+            i += 2;
+            tail_pow = pow1;
+        }
+        if len - i >= 2 {
+            acc1 = vfmaq_f64(acc1, vld1q_f64(ptr.add(i)), pow1);
+            i += 2;
+            tail_pow = pow2;
+        }
+        if len - i >= 2 {
+            acc2 = vfmaq_f64(acc2, vld1q_f64(ptr.add(i)), pow2);
+            i += 2;
+            tail_pow = pow3;
+        }
+
+        let acc = vaddq_f64(vaddq_f64(acc0, acc1), vaddq_f64(acc2, acc3));
+        let mut sum = vaddvq_f64(acc);
+
+        // at most one element left
+        if i < len {
+            sum += *ptr.add(i) * vgetq_lane_f64::<0>(tail_pow);
+        }
+
+        sum
     }
-
-    // Up to three whole pairs are left over; each already has its factors in pow_j, so the
-    // remainder costs no extra power arithmetic. `tail_pow` tracks the vector whose lane 0
-    // is the factor of the next unprocessed element.
-    let mut i = blocks * NEON_BLOCK;
-    let mut tail_pow = pow0;
-    if len - i >= 2 {
-        acc0 = vfmaq_f64(acc0, vld1q_f64(ptr.add(i)), pow0);
-        i += 2;
-        tail_pow = pow1;
-    }
-    if len - i >= 2 {
-        acc1 = vfmaq_f64(acc1, vld1q_f64(ptr.add(i)), pow1);
-        i += 2;
-        tail_pow = pow2;
-    }
-    if len - i >= 2 {
-        acc2 = vfmaq_f64(acc2, vld1q_f64(ptr.add(i)), pow2);
-        i += 2;
-        tail_pow = pow3;
-    }
-
-    let acc = vaddq_f64(vaddq_f64(acc0, acc1), vaddq_f64(acc2, acc3));
-    let mut sum = vaddvq_f64(acc);
-
-    // at most one element left
-    if i < len {
-        sum += *ptr.add(i) * vgetq_lane_f64::<0>(tail_pow);
-    }
-
-    sum
 }
 
 /// NPV and its derivative over the whole slice in one pass.
@@ -419,111 +437,117 @@ unsafe fn npv_simd_neon(base: f64, values: &[f64], start_from_zero: bool) -> f64
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 unsafe fn npv_with_deriv_neon(rate: f64, values: &[f64], start_index: usize) -> (f64, f64) {
-    use std::arch::aarch64::*;
+    // SAFETY: NEON is mandatory in the aarch64 base ISA, so the target feature is
+    // always satisfied. Every load is in bounds: the block loop stops at
+    // `blocks * NEON_BLOCK <= len`, each of the three pair steps is guarded by
+    // `len - i >= 2`, and the final single element by `i < len`.
+    unsafe {
+        use std::arch::aarch64::*;
 
-    let base = 1.0 + rate;
-    let inv_base = 1.0 / base;
-    let ib2 = inv_base * inv_base;
-    let ib4 = ib2 * ib2;
-    let ib8 = ib4 * ib4;
+        let base = 1.0 + rate;
+        let inv_base = 1.0 / base;
+        let ib2 = inv_base * inv_base;
+        let ib4 = ib2 * ib2;
+        let ib8 = ib4 * ib4;
 
-    // Matches `npv_with_deriv_autovec`: the discount exponent starts at 1 whatever
-    // `start_index` is — the caller has already handled element 0 — while `start_index`
-    // only feeds the derivative's index weights. The two coincide for the production
-    // call, which passes `&values[1..]` with `start_index == 1`.
-    let p0 = inv_base;
+        // Matches `npv_with_deriv_autovec`: the discount exponent starts at 1 whatever
+        // `start_index` is — the caller has already handled element 0 — while `start_index`
+        // only feeds the derivative's index weights. The two coincide for the production
+        // call, which passes `&values[1..]` with `start_index == 1`.
+        let p0 = inv_base;
 
-    let mut pow0 = vcombine_f64(vdup_n_f64(p0), vdup_n_f64(p0 * inv_base));
-    let mut pow1 = vmulq_n_f64(pow0, ib2);
-    let mut pow2 = vmulq_n_f64(pow0, ib4);
-    let mut pow3 = vmulq_n_f64(pow1, ib4);
-    let step = vdupq_n_f64(ib8);
+        let mut pow0 = vcombine_f64(vdup_n_f64(p0), vdup_n_f64(p0 * inv_base));
+        let mut pow1 = vmulq_n_f64(pow0, ib2);
+        let mut pow2 = vmulq_n_f64(pow0, ib4);
+        let mut pow3 = vmulq_n_f64(pow1, ib4);
+        let step = vdupq_n_f64(ib8);
 
-    let si = start_index as f64;
-    let mut idx0 = vcombine_f64(vdup_n_f64(si), vdup_n_f64(si + 1.0));
-    let mut idx1 = vaddq_f64(idx0, vdupq_n_f64(2.0));
-    let mut idx2 = vaddq_f64(idx0, vdupq_n_f64(4.0));
-    let mut idx3 = vaddq_f64(idx0, vdupq_n_f64(6.0));
-    let idx_step = vdupq_n_f64(NEON_BLOCK as f64);
+        let si = start_index as f64;
+        let mut idx0 = vcombine_f64(vdup_n_f64(si), vdup_n_f64(si + 1.0));
+        let mut idx1 = vaddq_f64(idx0, vdupq_n_f64(2.0));
+        let mut idx2 = vaddq_f64(idx0, vdupq_n_f64(4.0));
+        let mut idx3 = vaddq_f64(idx0, vdupq_n_f64(6.0));
+        let idx_step = vdupq_n_f64(NEON_BLOCK as f64);
 
-    let mut sum0 = vdupq_n_f64(0.0);
-    let mut sum1 = vdupq_n_f64(0.0);
-    let mut sum2 = vdupq_n_f64(0.0);
-    let mut sum3 = vdupq_n_f64(0.0);
-    // accumulate sum(i * v_i / base^i); scaled by -1/base once the loop is done
-    let mut wgt0 = vdupq_n_f64(0.0);
-    let mut wgt1 = vdupq_n_f64(0.0);
-    let mut wgt2 = vdupq_n_f64(0.0);
-    let mut wgt3 = vdupq_n_f64(0.0);
+        let mut sum0 = vdupq_n_f64(0.0);
+        let mut sum1 = vdupq_n_f64(0.0);
+        let mut sum2 = vdupq_n_f64(0.0);
+        let mut sum3 = vdupq_n_f64(0.0);
+        // accumulate sum(i * v_i / base^i); scaled by -1/base once the loop is done
+        let mut wgt0 = vdupq_n_f64(0.0);
+        let mut wgt1 = vdupq_n_f64(0.0);
+        let mut wgt2 = vdupq_n_f64(0.0);
+        let mut wgt3 = vdupq_n_f64(0.0);
 
-    let ptr = values.as_ptr();
-    let len = values.len();
-    let blocks = len / NEON_BLOCK;
+        let ptr = values.as_ptr();
+        let len = values.len();
+        let blocks = len / NEON_BLOCK;
 
-    for k in 0..blocks {
-        let i = k * NEON_BLOCK;
+        for k in 0..blocks {
+            let i = k * NEON_BLOCK;
 
-        let term0 = vmulq_f64(vld1q_f64(ptr.add(i)), pow0);
-        let term1 = vmulq_f64(vld1q_f64(ptr.add(i + 2)), pow1);
-        let term2 = vmulq_f64(vld1q_f64(ptr.add(i + 4)), pow2);
-        let term3 = vmulq_f64(vld1q_f64(ptr.add(i + 6)), pow3);
+            let term0 = vmulq_f64(vld1q_f64(ptr.add(i)), pow0);
+            let term1 = vmulq_f64(vld1q_f64(ptr.add(i + 2)), pow1);
+            let term2 = vmulq_f64(vld1q_f64(ptr.add(i + 4)), pow2);
+            let term3 = vmulq_f64(vld1q_f64(ptr.add(i + 6)), pow3);
 
-        sum0 = vaddq_f64(sum0, term0);
-        sum1 = vaddq_f64(sum1, term1);
-        sum2 = vaddq_f64(sum2, term2);
-        sum3 = vaddq_f64(sum3, term3);
+            sum0 = vaddq_f64(sum0, term0);
+            sum1 = vaddq_f64(sum1, term1);
+            sum2 = vaddq_f64(sum2, term2);
+            sum3 = vaddq_f64(sum3, term3);
 
-        wgt0 = vfmaq_f64(wgt0, term0, idx0);
-        wgt1 = vfmaq_f64(wgt1, term1, idx1);
-        wgt2 = vfmaq_f64(wgt2, term2, idx2);
-        wgt3 = vfmaq_f64(wgt3, term3, idx3);
+            wgt0 = vfmaq_f64(wgt0, term0, idx0);
+            wgt1 = vfmaq_f64(wgt1, term1, idx1);
+            wgt2 = vfmaq_f64(wgt2, term2, idx2);
+            wgt3 = vfmaq_f64(wgt3, term3, idx3);
 
-        pow0 = vmulq_f64(pow0, step);
-        pow1 = vmulq_f64(pow1, step);
-        pow2 = vmulq_f64(pow2, step);
-        pow3 = vmulq_f64(pow3, step);
+            pow0 = vmulq_f64(pow0, step);
+            pow1 = vmulq_f64(pow1, step);
+            pow2 = vmulq_f64(pow2, step);
+            pow3 = vmulq_f64(pow3, step);
 
-        idx0 = vaddq_f64(idx0, idx_step);
-        idx1 = vaddq_f64(idx1, idx_step);
-        idx2 = vaddq_f64(idx2, idx_step);
-        idx3 = vaddq_f64(idx3, idx_step);
+            idx0 = vaddq_f64(idx0, idx_step);
+            idx1 = vaddq_f64(idx1, idx_step);
+            idx2 = vaddq_f64(idx2, idx_step);
+            idx3 = vaddq_f64(idx3, idx_step);
+        }
+
+        let mut i = blocks * NEON_BLOCK;
+        let mut tail_pow = pow0;
+        if len - i >= 2 {
+            let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow0);
+            sum0 = vaddq_f64(sum0, term);
+            wgt0 = vfmaq_f64(wgt0, term, idx0);
+            i += 2;
+            tail_pow = pow1;
+        }
+        if len - i >= 2 {
+            let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow1);
+            sum1 = vaddq_f64(sum1, term);
+            wgt1 = vfmaq_f64(wgt1, term, idx1);
+            i += 2;
+            tail_pow = pow2;
+        }
+        if len - i >= 2 {
+            let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow2);
+            sum2 = vaddq_f64(sum2, term);
+            wgt2 = vfmaq_f64(wgt2, term, idx2);
+            i += 2;
+            tail_pow = pow3;
+        }
+
+        let mut sum = vaddvq_f64(vaddq_f64(vaddq_f64(sum0, sum1), vaddq_f64(sum2, sum3)));
+        let mut weighted = vaddvq_f64(vaddq_f64(vaddq_f64(wgt0, wgt1), vaddq_f64(wgt2, wgt3)));
+
+        // at most one element left
+        if i < len {
+            let term = *ptr.add(i) * vgetq_lane_f64::<0>(tail_pow);
+            sum += term;
+            weighted += (start_index + i) as f64 * term;
+        }
+
+        (sum, -weighted * inv_base)
     }
-
-    let mut i = blocks * NEON_BLOCK;
-    let mut tail_pow = pow0;
-    if len - i >= 2 {
-        let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow0);
-        sum0 = vaddq_f64(sum0, term);
-        wgt0 = vfmaq_f64(wgt0, term, idx0);
-        i += 2;
-        tail_pow = pow1;
-    }
-    if len - i >= 2 {
-        let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow1);
-        sum1 = vaddq_f64(sum1, term);
-        wgt1 = vfmaq_f64(wgt1, term, idx1);
-        i += 2;
-        tail_pow = pow2;
-    }
-    if len - i >= 2 {
-        let term = vmulq_f64(vld1q_f64(ptr.add(i)), pow2);
-        sum2 = vaddq_f64(sum2, term);
-        wgt2 = vfmaq_f64(wgt2, term, idx2);
-        i += 2;
-        tail_pow = pow3;
-    }
-
-    let mut sum = vaddvq_f64(vaddq_f64(vaddq_f64(sum0, sum1), vaddq_f64(sum2, sum3)));
-    let mut weighted = vaddvq_f64(vaddq_f64(vaddq_f64(wgt0, wgt1), vaddq_f64(wgt2, wgt3)));
-
-    // at most one element left
-    if i < len {
-        let term = *ptr.add(i) * vgetq_lane_f64::<0>(tail_pow);
-        sum += term;
-        weighted += (start_index + i) as f64 * term;
-    }
-
-    (sum, -weighted * inv_base)
 }
 
 /// SIMD tier selected once per process from CPU support + the `ENABLE_*` overrides.

--- a/src/core/scheduled/day_count.rs
+++ b/src/core/scheduled/day_count.rs
@@ -1,8 +1,8 @@
 use std::{cmp::min, fmt, str::FromStr};
 
 use time::{
-    util::{days_in_month, is_leap_year},
     Date, Month,
+    util::{days_in_month, is_leap_year},
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/src/core/scheduled/mod.rs
+++ b/src/core/scheduled/mod.rs
@@ -2,6 +2,6 @@ mod day_count;
 mod xirr;
 mod xnfv;
 
-pub use day_count::{days_between, year_fraction, DayCount};
+pub use day_count::{DayCount, days_between, year_fraction};
 pub use xirr::*;
 pub use xnfv::*;

--- a/src/core/scheduled/xirr.rs
+++ b/src/core/scheduled/xirr.rs
@@ -1,6 +1,6 @@
-use super::{year_fraction, DayCount};
+use super::{DayCount, year_fraction};
 use crate::core::{
-    models::{validate, validate_length, DateLike, InvalidPaymentsError},
+    models::{DateLike, InvalidPaymentsError, validate, validate_length},
     optimize::{brentq, newton_raphson_2},
     utils::{fast_pow, initial_guess},
 };

--- a/src/core/scheduled/xnfv.rs
+++ b/src/core/scheduled/xnfv.rs
@@ -1,6 +1,6 @@
-use super::{year_fraction, DayCount};
+use super::{DayCount, year_fraction};
 use crate::core::{
-    models::{validate, DateLike, InvalidPaymentsError},
+    models::{DateLike, InvalidPaymentsError, validate},
     periodic::fv,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,15 @@
+//! `unsafe` in this crate is confined to the SIMD kernels in `core::periodic::npv`, where
+//! it covers two obligations: the `#[target_feature]` preconditions discharged by the
+//! cached CPU probe in `simd_tier`, and the raw loads whose bounds the kernels establish
+//! themselves. Denying this lint keeps those obligations written down rather than implied
+//! by the `unsafe fn` signature -- and it applies on every target, which matters here
+//! because half the kernels are behind `cfg(target_arch)` and never compiled by CI.
+#![deny(unsafe_op_in_unsafe_fn)]
+
 mod conversions;
 mod core;
 
 pub use core::{
-    cumipmt, cumprinc, days_between, fv, ipmt, irr, mirr, nfv, nper, npv, pmt, ppmt, pv, rate, xfv,
-    xirr, xnfv, xnpv, year_fraction, zero_crossing_points, DateLike, DayCount,
+    DateLike, DayCount, cumipmt, cumprinc, days_between, fv, ipmt, irr, mirr, nfv, nper, npv, pmt,
+    ppmt, pv, rate, xfv, xirr, xnfv, xnpv, year_fraction, zero_crossing_points,
 };

--- a/tests/common/helpers.rs
+++ b/tests/common/helpers.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::BufReader, path::Path};
 
 use csv::ReaderBuilder;
-use time::{macros::format_description, Date};
+use time::{Date, macros::format_description};
 
 /// Loads payments from a CSV file
 #[allow(dead_code)]

--- a/tests/test_conversion.rs
+++ b/tests/test_conversion.rs
@@ -1,4 +1,4 @@
-use pyxirr::{xirr, DateLike};
+use pyxirr::{DateLike, xirr};
 use rstest::rstest;
 use time::macros::date;
 

--- a/tests/test_scheduled.rs
+++ b/tests/test_scheduled.rs
@@ -1,6 +1,6 @@
-use pyxirr::{xfv, xirr, xnfv, xnpv, DateLike};
+use pyxirr::{DateLike, xfv, xirr, xnfv, xnpv};
 use rstest::rstest;
-use time::{macros::date, Date};
+use time::{Date, macros::date};
 
 use crate::common::{load_payments_from_csv, split_payments};
 


### PR DESCRIPTION
One commit, 19 files. The diff looks bigger than it is: 582 of the 638 changed lines are
`src/core/periodic/npv.rs`, and almost all of that is re-indentation from wrapping four
kernel bodies in `unsafe` blocks. 17 more lines are import reordering across 14 files.
The substantive change is about a dozen lines.

## Why this is more than a version bump

`cargo fix --edition` handled the mechanical part. Three things it could not:

**It never saw the NEON kernels.** They sit behind `cfg(target_arch = "aarch64")`, so an
x86 host does not compile them and they were not migrated. Forcing the lint made the gap
visible: x86 came back clean while aarch64 reported ~20 unwrapped unsafe operations in
`npv_simd_neon` and `npv_with_deriv_neon`.

**`unsafe_op_in_unsafe_fn` is allow-by-default** in the current toolchain, and `cargo fix`
only enables it transiently for the migration. Left at the default, the x86 kernels would
carry `unsafe` blocks and NEON would not, with nothing to catch the divergence. This PR
denies it crate-wide in `lib.rs` instead — that lint is the whole point of the migration
for this crate, and denying it applies on every target.

**Its output was compatibility-shaped, not idiomatic.** Three escape hatches replaced:

| cargo fix produced | this PR |
| --- | --- |
| `$a:expr_2021` (17 sites) | `$a:expr` — these macros only take ordinary expressions |
| `\|&(ref _r, &v)\| v > 0.0` | `\|&(_, v)\| *v > 0.0` — same semantics, no `ref` binding |
| `fn f() -> f64 { unsafe {` … `}}` | an indented block per function, each with a `// SAFETY:` comment |

The SAFETY comments name both obligations the `unsafe` covers: the `#[target_feature]`
precondition discharged by the cached CPU probe in `simd_tier`, and the specific bound
that puts each load in range (`blocks * BLOCK <= len`, the `len - i >= 4` / `>= 2`
remainder guards, the `i < len` tail condition).

## Also

`.rustfmt.toml` pinned `edition = "2021"` and would have fought the package on any direct
`rustfmt` invocation, so it is bumped too. The 17 lines of import reordering are the 2024
style edition sorting types ahead of functions.

Worth knowing: `cargo fmt --check` was already failing before this branch — verified at
the merge base. That drift predates the migration and is fixed here rather than
introduced.

## Testing

223 tests pass on all three x86 dispatch tiers (`ENABLE_AVX2=0` and
`ENABLE_AVX2=0 ENABLE_AVX=0` force the lower ones, since a plain run only exercises the
runner's best). Clippy and `cargo fmt --check` are clean for both `x86_64` and
`aarch64-unknown-linux-gnu`. Release build and benches compile for both. Kernel
benchmarks are unchanged — wrapping a body in `unsafe` is codegen-neutral.

## Reviewing this efficiently

Read `src/lib.rs`, `src/core/periodic.rs`, `Cargo.toml` and `.rustfmt.toml` — that is the
actual change. In `src/core/periodic/npv.rs`, read the four `// SAFETY:` comments and
skim the rest; `git diff -w` collapses it to almost nothing. The 14 single-line files are
import order only.

The aarch64 path is compile- and lint-verified only. There is no ARM runner and no
emulator, so the NEON kernels have not been *run* since the migration — worth a
`cargo test` on Apple silicon before merging if that is convenient.
